### PR TITLE
feat: occupancy を /common/occupancy にマウント

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -69,6 +69,7 @@ services:
       - ${HOME}/.ssh:/root/.ssh
       - ./common:/common # common scripts
       - $ACSL_WORK_DIR/launcher:/common/ros_launcher
+      - $ACSL_WORK_DIR/isaac_sim/environments/bld10/occupancy:/common/occupancy # 占有格子 (建屋 environment に集約)
       - /dev:/dev # GPIO and USB devices
       - vscode-server:/root/.vscode-server # VScode setting (preserve VScode extension)
       - $ACSL_WORK_DIR/packages:/root/ros2_ws/src/ros_packages


### PR DESCRIPTION
## やったこと
- 全コンテナ共通の `common` サービスに `$ACSL_WORK_DIR/isaac_sim/environments/bld10/occupancy:/common/occupancy` を追加。
- 占有格子マップ (建屋データ) を environment_bld10 に集約する方針に対応。slam_toolbox / nav2 がここから占有格子を読み書きする。

## やっていないこと
- マウント先名 `/common/occupancy` は固定とした (要望あれば変更可)。
- env リポ全体ではなく occupancy サブディレクトリのみマウント。

## これで可能になること
- project_rf_rover の `launch_slam_toolbox.sh`/`launch_nav2.sh` が `/common/occupancy` から占有格子を読み書きできる。

## 退行の可能性
- 既存マウントへの変更はなく追加のみ。書き込み要のため `:ro` なし。

## 検証
- [ ] `dup slam_toolbox localization bld10_4F "[...]"` で map_server が `/map` を publish
- [ ] `dup slam_toolbox save_map` が `environment_bld10/occupancy/map.{pgm,yaml}` に出力

> 関連: project_rf_rover (launcher パス変更), environment_bld10 (占有格子集約) の PR とセット。