### PR TITLE
feat: environment を 1 本の親マウントで全コンテナにライブ配送

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -56,6 +56,7 @@ services:
       - RMW_IMPLEMENTATION=rmw_${RMW:-fastrtps}_cpp
       - FASTDDS_BUILTIN_TRANSPORTS=${FASTDDS_BUILTIN_TRANSPORTS:-UDPv4}
       - ROS_USE_SIM_TIME=${ROS_USE_SIM_TIME:-false}
+      - ENV_BUILDING=${ENV_BUILDING:-bld10} # active 建屋名 (environment_<name>)
       # WSL : thanks to : https://dev.classmethod.jp/articles/wsl2-docker-gui-app-windows-display/
       - DISPLAY=${DISPLAY}
       - WAYLAND_DISPLAY=${WAYLAND_DISPLAY:-0}
@@ -69,7 +70,13 @@ services:
       - ${HOME}/.ssh:/root/.ssh
       - ./common:/common # common scripts
       - $ACSL_WORK_DIR/launcher:/common/ros_launcher
-      - $ACSL_WORK_DIR/isaac_sim/environments/bld10/occupancy:/common/occupancy # 占有格子 (建屋 environment に集約)
+      # 建屋 environment を 1 本の親マウントで全コンテナにライブ配送 (複数建屋対応)
+      #   /root/environment/<name>/{config,occupancy,omni,...}
+      # rw: node_capture / save_map / serialize がコンテナから書く
+      - $ACSL_WORK_DIR/isaac_sim/environments:/root/environment
+      # 占有格子は active 建屋の occupancy を /common/occupancy にも別名 bind
+      # (launch_slam_toolbox.sh / launch_nav2.sh を無改修で建屋切替できるよう ENV_BUILDING で切替)
+      - $ACSL_WORK_DIR/isaac_sim/environments/${ENV_BUILDING:-bld10}/occupancy:/common/occupancy
       - /dev:/dev # GPIO and USB devices
       - vscode-server:/root/.vscode-server # VScode setting (preserve VScode extension)
       - $ACSL_WORK_DIR/packages:/root/ros2_ws/src/ros_packages


### PR DESCRIPTION
## やったこと
- 全コンテナ共通の \`common\` サービスに **environments 親マウント** を追加:
  - \`\$ACSL_WORK_DIR/isaac_sim/environments\` → \`/root/environment\` (rw)
  - 建屋ごとに \`/root/environment/<name>/{config,occupancy,omni,...}\` が見える
- \`/common/occupancy\` を \`\${ENV_BUILDING:-bld10}\` の occupancy に向けた別名 bind に変更
  → \`launch_slam_toolbox.sh\` / \`launch_nav2.sh\` 無改修で建屋切替可能
- \`ENV_BUILDING=\${ENV_BUILDING:-bld10}\` をコンテナ環境変数に追加

## やっていないこと
- Dockerfile への env ベイクは元から存在しなかったため変更なし (ベイク廃止は no-op)。
- robot 側コード/launcher は PR project_rf_rover#11 で対応済み (\`/root/environment/<name>/config\` を最優先で解決)。

## これで可能になること
- host で \`environment_<name>/config\` を編集 → コンテナ再ビルド不要で反映 (\`git pull\` で全配送)
- \`ENV_BUILDING=yc_bld7 dup ...\` で別建屋に切替 (マウント追加不要)
- \`dup slam_toolbox save_map\` / \`serialize_map\` が host の \`environment_<name>/occupancy/\` に出る

## 退行の可能性
- 初回 \`dup\` 起動時、コンテナ内 \`/root/environment\` の所有/権限が想定どおりか要確認 (host の sekiguchi UID と一致しないと書き込み権限で躓く可能性)。
- \`ENV_BUILDING\` を上書きする場合は shell に export してから \`dup\` を呼ぶこと (docker compose の env 補完時刻に解決される)。

## 検証 (受入条件)
- [ ] host で \`isaac_sim/environments/bld10/config/maps/bld10_4F_slice.json\` 編集 → コンテナ再ビルド無しで \`dup rover node_capture edges 4\` の起動ログに反映
- [ ] \`dup all isaacsim\` のログに \`Environment config dir: /root/environment/bld10/config\` が出る (旧 \`/root/environment_bld10\` でない)
- [ ] \`dup slam_toolbox save_map\` の出力が host の \`isaac_sim/environments/bld10/occupancy/\` に出る
- [ ] \`ENV_BUILDING=yc_bld7 dup ...\` で別建屋切替 (config.environment.name: yc_bld7 と併せる)