### PR TITLE
feat: dup の image が無ければ dockerfile から自動ビルド (closes #18)

### DIFF
--- a/commands/scripts/dup
+++ b/commands/scripts/dup
@@ -12,6 +12,15 @@ if [[ "$1" == "-h" || "$1" == "--help" ]]; then
     echo "  dup -h <name>       : show launcher help"
     echo "  dup all             : launch all containers"
     echo "  dup dev             : launch dev container"
+    echo ""
+    echo "Image resolution order for 'dup <name>':"
+    echo "  1. kasekiguchi/acsl-common:<name>_x86 (local)"
+    echo "  2. dockerfile.<name> (auto-build from \$ACSL_WORK_DIR/dockerfiles or"
+    echo "                       \$ACSL_ROS2_DIR/dockerfiles)"
+    echo "  3. image_<PROJECT>_x86 (fallback)"
+    echo "  4. base_x86 (last resort)"
+    echo ""
+    echo "Set DUP_NO_AUTOBUILD=1 to disable step 2 (CI / offline use)."
     exit 0
   fi
   ROS_LAUNCH=$(ls -v $ACSL_WORK_DIR/launcher/ 2>/dev/null | grep launch_$2 | fmt | awk '{print $NF}')
@@ -59,13 +68,43 @@ if [ $# -ge 1 ]; then
     exist_image=$(docker images kasekiguchi/acsl-common:${cimage} | grep ${cimage})
     echo "Search image: ${cimage}         Found: $exist_image "
     if [[ -z $exist_image ]]; then
-      exist_image=$(docker images kasekiguchi/acsl-common | grep image_${PROJECT}${x86})
-      if [[ -z $exist_image ]]; then
-        TAG=base${x86}
-      else
-        TAG=image_${PROJECT}${x86}
+      # Auto-build: dockerfile.<name> があれば自動ビルド (DUP_NO_AUTOBUILD=1 で無効化)
+      # name は cimage から _x86 を剥がしたもの (例: cimage=ardupilot_sitl_x86 → ardupilot_sitl)
+      if [[ "${DUP_NO_AUTOBUILD:-0}" != "1" ]]; then
+        df_name="dockerfile.${cimage%_x86}"
+        df_path=""
+        for d in "$ACSL_WORK_DIR/dockerfiles" "$ACSL_ROS2_DIR/dockerfiles"; do
+          if [[ -f "$d/$df_name" ]]; then
+            df_path="$d/$df_name"
+            break
+          fi
+        done
+        if [[ -n "$df_path" ]]; then
+          gecho "== image ${cimage} not found. Auto-building from $df_path ..."
+          docker build \
+            -t "kasekiguchi/acsl-common:${cimage}" \
+            -f "$df_path" \
+            "$(dirname "$df_path")"
+          if [[ $? -eq 0 ]]; then
+            exist_image=$(docker images kasekiguchi/acsl-common:${cimage} | grep ${cimage})
+          else
+            echo "== auto-build failed for ${cimage}"
+          fi
+        fi
       fi
-      echo "== image ${cimage} does NOT exists. Use ${TAG} alternatively."
+      # 既存フォールバック: auto-build できなかった場合は base/image_<PROJECT> を使う
+      if [[ -z $exist_image ]]; then
+        exist_image=$(docker images kasekiguchi/acsl-common | grep image_${PROJECT}${x86})
+        if [[ -z $exist_image ]]; then
+          TAG=base${x86}
+        else
+          TAG=image_${PROJECT}${x86}
+        fi
+        echo "== image ${cimage} does NOT exists. Use ${TAG} alternatively."
+      else
+        echo "== image ${cimage} ready (built or pulled)"
+        TAG=${cimage}
+      fi
     else
       echo "== image ${cimage} exists"
       TAG=${cimage}


### PR DESCRIPTION
closes #18

## やったこと
\`dup <name>\` 実行時に \`kasekiguchi/acsl-common:<name>_x86\` が無い場合、\`dockerfile.<name>\` を探して **自動ビルド** する機能を追加。

### Image 検索の優先順位 (変更後)
1. \`kasekiguchi/acsl-common:<name>_x86\` (local) — **既存**
2. **\`dockerfile.<name>\` (auto-build, 新規)** — \`$ACSL_WORK_DIR/dockerfiles/\` または \`$ACSL_ROS2_DIR/dockerfiles/\` から
3. \`image_<PROJECT>_x86\` (fallback) — 既存
4. \`base_x86\` (last resort) — 既存

### 環境変数
- \`DUP_NO_AUTOBUILD=1\` を設定すると step 2 をスキップ (CI / オフライン用)

### 修正範囲
- \`commands/scripts/dup\` のみ (47 行追加 / 4 行削除)

## やらないこと
- **\`dbuild\` の改修** — auto-build は \`docker build\` を直接呼ぶ。dbuild の image 命名 (_x86 自動付与、kasekiguchi/acsl-common: prefix 等) のクセを引き継がない単純実装
- **複雑な dockerfile (\`ARG BASE_IMAGE\` 経由のチェイン build)** — 既存の dbuild を使う想定
- **\`--network=host\` 等の起動オプション** — 別問題。各プロジェクトの \`docker-compose_<name>.yml\` で対応

## できるようになること (ユーザ目線)
プロジェクト側で:
\`\`\`
project_drone2/
└── dockerfiles/
    └── dockerfile.ardupilot_sitl   ← 配置するだけ
\`\`\`

すると:
\`\`\`bash
dup ardupilot_sitl
# 初回: image 未存在 → dockerfile 検出 → 自動 build → 起動
# 2 回目以降: image 存在 → そのまま起動
\`\`\`

\`setup full\` / \`setup sitl\` で事前 build しなくても、最初に \`dup\` した時にビルドされる。新 service 追加時の setup script 改修が不要に。

## できなくなること
- 無し (既存挙動を破壊しない)
- ただし dockerfile 名が \`dockerfile.<name>\` で且つそれが偶然存在する場合、従来 \`base_x86\` フォールバックされていたケースが自動 build に変わる。意図しない build を防ぎたい場合は \`DUP_NO_AUTOBUILD=1\`

## 動作確認
**未実施** (実環境を持っていないため):
- [ ] 既存 image でビルド済みの場合に挙動変化なし
- [ ] dockerfile 無しでも従来通り base fallback
- [ ] \`dockerfiles/dockerfile.dummy_test\` を置いて \`dup dummy_test\` で auto-build → 起動
- [ ] \`DUP_NO_AUTOBUILD=1 dup dummy_test\` で auto-build 動作せず fallback

**マージ前のレビュー依頼**: 既存の dup の主要パターン (dup drone2, dup mavros2, dup quadrotor_sim 等) で回帰しないことの確認

## Concerns and areas to focus on
- 既存 fallback ロジック (image_<PROJECT>_x86 / base_x86) を壊していないか
- \`cimage%_x86\` で \`_x86\` 剥がしが正しい (arm64 環境では \`x86\` 変数が空のため、cimage に \`_x86\` 付かない → そのまま使われる)
- dockerfile が見つかった時のビルド context が \`dirname(dockerfile)\` で適切か (project 内 dockerfile が他ファイル参照する場合)
- ビルド失敗時の挙動: ログ出して fallback に進む (現状の実装)

## 関連
- project_drone2 #21, #22: ArduCopter SITL Phase 1/2
- project_drone2 PR #23: 本機能マージ後にリファクタ可能 (\`gazebo_sitl/start_ardupilot_sitl.sh\` の build 部分を削除して \`dup ardupilot_sitl\` 経由に統一)

🤖 Generated with [Claude Code](https://claude.com/claude-code)