### PR TITLE
fix: docker-compose 上書きの検出を ACSL_WORK_DIR からに修正

### DIFF
--- a/commands/scripts/dup
+++ b/commands/scripts/dup
@@ -36,8 +36,10 @@ if [[ "$1" =~ ^--image= ]]; then
   shift
 fi
 compose=" -f ${ACSL_ROS2_DIR}/docker/docker-compose.yml "
-local_compose=$(ls . | grep docker-compose_${1}.yml)
-if [[ -n ${local_compose} ]]; then
+# project 固有の docker-compose 上書きは必ず $ACSL_WORK_DIR から探す。
+# dup all 経由で project_launch.sh が cd した後でも検出できるように
+# CWD ではなく ACSL_WORK_DIR を使う。
+if [[ -f "${ACSL_WORK_DIR}/docker-compose_${1}.yml" ]]; then
   compose=${compose}" -f ${ACSL_WORK_DIR}/docker-compose_${1}.yml "
   echo ":::::::::::::::::::::::::::::"
   echo ${compose}


### PR DESCRIPTION
## やったこと
\`dup\` の project 固有 docker-compose 上書きファイル検出を CWD ではなく \`ACSL_WORK_DIR\` から行うように修正。

### 修正前
\`\`\`bash
local_compose=\$(ls . | grep docker-compose_\${1}.yml)
\`\`\`

### 修正後
\`\`\`bash
if [[ -f "\${ACSL_WORK_DIR}/docker-compose_\${1}.yml" ]]; then
\`\`\`

## 症状 (修正前)
\`dup all <MODE>\` 経由で起動すると、\`project_launch.sh\` 内の
\`\`\`bash
cd \${ACSL_ROS2_DIR}/commands/scripts
\`\`\`
で CWD が acsl_infra 配下になり、\`ls . | grep docker-compose_*.yml\` が project の上書きファイルを発見できない。

これにより project_drone2 の \`docker-compose_ardupilot_sitl.yml\` (network_mode: host / entrypoint 上書き / volume 追加) がロードされず、ArduCopter SITL コンテナが標準 ROS2 entrypoint で起動してしまっていた:
\`\`\`
===== Ready! =====       ← 標準 entrypoint.sh が動いている (上書き失敗)
/opt/ros/jazzy/bin       ← ROS2 image (network/mount 上書きも失敗)
/root/ardupilot/ArduCopter: No such file or directory
\`\`\`

## できるようになること
\`docker-compose_<name>.yml\` を \`ACSL_WORK_DIR\` (= project root) に置けば、\`dup\` を CWD どこから呼んでも上書きが適用される。

## デグレ懸念
- \`dup\` を CWD = project root で実行していた既存ユースは挙動変化なし (ACSL_WORK_DIR から見ても同じファイルが見つかる)
- ACSL_WORK_DIR を別の場所に向けるカスタム運用は影響あり (希少)

## 検証
- [x] 構文チェック
- [ ] project_drone2 で \`dup all SITL_AP\` の \`docker-compose_ardupilot_sitl.yml\` 上書きが適用される

## 関連
- project_drone2 dlogs にて override 不適用が判明
- project_drone2 PR #24 (SITL_AP refactor) との組合せ