### PR TITLE
fix: dup auto-build で ARG ベース dockerfile を skip

### DIFF
--- a/commands/scripts/dup
+++ b/commands/scripts/dup
@@ -81,6 +81,13 @@ if [ $# -ge 1 ]; then
             break
           fi
         done
+        # ARG ベース dockerfile (FROM ${BASE_IMAGE} など) は dbuild で --build-arg
+        # 付きでビルドする想定。auto-build (docker build 単純呼出) では BASE_IMAGE
+        # が空になり失敗する。事前に skip する。
+        if [[ -n "$df_path" ]] && grep -qE '^[[:space:]]*FROM[[:space:]]+\$\{?[A-Z_]+' "$df_path"; then
+          gecho "== dockerfile.${cimage%_x86} has ARG-based FROM; skipping auto-build (use dbuild)"
+          df_path=""
+        fi
         if [[ -n "$df_path" ]]; then
           gecho "== image ${cimage} not found. Auto-building from $df_path ..."
           docker build \


### PR DESCRIPTION
## 症状
\`dup drone2 ...\` (= dup all SITL_GZ_PX4 経由) で以下のエラー:

\`\`\`
=> [internal] load build definition from dockerfile.drone2
=> WARN: InvalidDefaultArgInFrom: Default value for ARG \${BASE_IMAGE} ...
ERROR: failed to build: failed to solve: base name (\${BASE_IMAGE}) should not be blank
== auto-build failed for drone2_x86
== image drone2_x86 does NOT exists. Use image_drone2_x86 alternatively.
\`\`\`

(その後フォールバックで image_drone2_x86 を使って起動するので最終結果は OK だが、無駄なビルド試行 + 紛らわしいエラー)

## 原因
PR #19 で入れた dup auto-build が dockerfile.<name> を見つけたら無条件に \`docker build\` (--build-arg なし) を呼ぶため、\`ARG BASE_IMAGE\` を必要とする dockerfile.drone2 等が空 ARG で失敗していた。

dockerfile.drone2 は \`dbuild\` で BASE_IMAGE を \`--build-arg\` で渡す前提のチェーン build 用。auto-build (単純な docker build) では使えない。

## 修正
dockerfile の FROM 行が \`\${VAR}\` または \`\$VAR\` を含む場合は dbuild 用とみなし auto-build を skip:

\`\`\`bash
if grep -qE '^[[:space:]]*FROM[[:space:]]+\\\$\\{?[A-Z_]+' "\$df_path"; then
  gecho "== dockerfile.\${name} has ARG-based FROM; skipping auto-build (use dbuild)"
  df_path=""
fi
\`\`\`

### 区別される dockerfile
- 自己完結型 (literal FROM): auto-build 対象 ✓
  \`\`\`
  FROM ubuntu:22.04
  \`\`\`
- チェーン build 用 (ARG ベース): skip ✗
  \`\`\`
  ARG BASE_IMAGE
  FROM \${BASE_IMAGE}
  \`\`\`

## できるようになること
- \`dup drone2\` (チェーン build 用 dockerfile.drone2 を使う) でも auto-build がエラーを出さず、即フォールバックに進む
- 自己完結型 dockerfile (dockerfile.ardupilot_sitl 等) は引き続き auto-build 対象

## デグレ懸念
- 無し (skip するだけなので既存のフォールバックロジックに進む)

## 関連
- PR #19 (auto-build 機能の初版)
- PR #20 (docker-compose 上書き検出の CWD 修正)
- project_drone2 #26 (image: 明示)