### PR TITLE
feat: dpx4 - PX4 SITL の px4-* module を host から叩く shortcut

### DIFF
--- a/commands/scripts/dpx4
+++ b/commands/scripts/dpx4
@@ -1,0 +1,71 @@
+#! /usr/bin/bash
+# Run px4-* module command inside px4_sitl container from host.
+#
+# project_drone2 の SITL_GZ_PX4 で起動する px4_sitl コンテナ内で動作中の
+# PX4 SITL daemon に対して、外から各 module wrapper を叩くための shortcut。
+#
+# PX4 は module 式 daemon で uORB IPC 経由で外部から status 確認や
+# command 発射ができる。各 module 用 wrapper binary が
+#   /root/PX4-Autopilot/build/px4_sitl_default/bin/px4-<module>
+# にあるので、それを `docker exec px4_sitl ...` で叩く処理を 1 行に短縮する。
+#
+# Usage:
+#   dpx4 commander status        # vehicle 全体の状態 (mode/armed/health)
+#   dpx4 commander check         # preflight チェックを今すぐ実行
+#   dpx4 commander preflight_check
+#   dpx4 gz_bridge status        # Gazebo bridge module 状態
+#   dpx4 mavlink status          # MAVLink stream 状態
+#   dpx4 ekf2 status             # EKF2 推定状態
+#   dpx4 sensors status          # sensor pipeline 状態
+#   dpx4 listener vehicle_status # uORB topic を 1 回 dump
+#   dpx4 uorb top -1             # uORB topic publish rate ランキング
+#   dpx4 param show COM_*        # parameter 値表示 (wildcard 可)
+#   dpx4 param set COM_X Y       # parameter 設定 (注: 永続化は別)
+#   dpx4 -h                      # この help (running なら module 一覧も)
+#
+# 前提:
+#   - px4_sitl コンテナが running (dup all SITL_GZ_PX4 で起動済)
+#   - 内部の px4 SITL build path が固定: /root/PX4-Autopilot/build/px4_sitl_default/bin/
+#
+# ArduPilot 用の同等コマンドは無い (AP SITL は単一 binary で module CLI 出さない)。
+# SITL_AP のデバッグは MAVProxy 端末 / MAVROS service / dataflash log を使う。
+
+CONTAINER=px4_sitl
+PX4_BIN_DIR=/root/PX4-Autopilot/build/px4_sitl_default/bin
+
+if [[ "$1" == "-h" || "$1" == "--help" || -z "$1" ]]; then
+  cat <<'USAGE'
+Usage: dpx4 <module> [args...]
+  Run px4-<module> inside px4_sitl container.
+
+Examples:
+  dpx4 commander status         # vehicle 状態 (mode / armed / health)
+  dpx4 commander check          # preflight チェック
+  dpx4 gz_bridge status         # Gazebo bridge 状態 (Issue #81 diag)
+  dpx4 mavlink status           # MAVLink stream 状態
+  dpx4 ekf2 status              # EKF2 推定状態
+  dpx4 listener vehicle_status  # uORB topic を 1 回 dump
+  dpx4 uorb top -1              # uORB rate ランキング
+  dpx4 param show COM_*         # parameter 表示
+
+Requires px4_sitl container running (dup all SITL_GZ_PX4).
+USAGE
+  if docker inspect -f '{{.State.Running}}' ${CONTAINER} >/dev/null 2>&1; then
+    echo ""
+    echo "Available px4-* modules in ${CONTAINER}:"
+    docker exec ${CONTAINER} ls ${PX4_BIN_DIR} 2>/dev/null \
+      | grep '^px4-' | sed 's/^px4-/  /' | head -60
+  else
+    echo ""
+    echo "(${CONTAINER} not running — start with: dup all SITL_GZ_PX4)"
+  fi
+  exit 0
+fi
+
+if ! docker inspect -f '{{.State.Running}}' ${CONTAINER} >/dev/null 2>&1; then
+  echo "[dpx4] ERROR: container '${CONTAINER}' is not running." >&2
+  echo "[dpx4]        Start it first: dup all SITL_GZ_PX4" >&2
+  exit 1
+fi
+
+exec docker exec ${CONTAINER} "${PX4_BIN_DIR}/px4-$1" "${@:2}"


### PR DESCRIPTION
## やったこと

`acsl_infra/commands/scripts/dpx4` を新規追加。project_drone2 の SITL_GZ_PX4 で起動する `px4_sitl` コンテナ内の PX4 SITL daemon に対して、外から module wrapper (`px4-commander`, `px4-gz_bridge`, `px4-listener` 等) を呼び出すための host-side shortcut。

## 動機

PX4 SITL は module 式 daemon で、uORB IPC 経由で外部 process から状態確認・コマンド発射ができる:

```bash
docker exec px4_sitl /root/PX4-Autopilot/build/px4_sitl_default/bin/px4-commander status
docker exec px4_sitl /root/PX4-Autopilot/build/px4_sitl_default/bin/px4-gz_bridge status
```

毎回これだとデバッグで疲れるので `dpx4 commander status` で済むようにする。

特に project_drone2 Issue #81 (SITL_GZ_PX4 で PX4 が motor command を Gazebo に出さない問題) のデバッグで使用予定。

## 用例

```bash
dpx4 commander status         # vehicle 全体の状態 (mode/armed/health)
dpx4 commander check          # preflight チェック
dpx4 gz_bridge status         # Gazebo bridge 状態 (Issue #81 の核心)
dpx4 mavlink status           # MAVLink stream 状態
dpx4 ekf2 status              # EKF2 推定状態
dpx4 listener vehicle_status  # uORB topic を 1 回 dump
dpx4 uorb top -1              # uORB rate ランキング
dpx4 param show COM_*         # parameter 値表示 (wildcard 可)
dpx4 -h                       # help + 利用可能 module 一覧 (running 時)
```

## 機能

- `-h` / 引数なしで Usage を表示。container running 時は `ls /root/.../bin/px4-*` で利用可能 module を自動列挙
- container running チェック → 動いてなければ ERROR で抜ける
- 引数 1 が module 名、2 以降を wrapper に転送 (`exec docker exec ...`)

## ArduPilot 系には類似コマンドなし

ArduPilot SITL は単一 binary で module CLI を提供しないアーキテクチャ。AP のデバッグは:
- MAVProxy 端末 (SITL_AP では `--no-mavproxy` で外したので使えない)
- MAVROS service / topic 経由
- dataflash log

で行う。`dap` 相当のコマンドは作れない/作る意味が薄い。

## なぜ acsl_infra か

`commands/scripts/` 配下は `setup_bashrc` で `PATH` に追加されるため、ここに置けば全 host で `dpx4` が即叩ける。

他 project (drone2 以外) では `px4_sitl` コンテナが存在しないが、その場合は `[dpx4] ERROR: container 'px4_sitl' is not running.` を吐いて exit 1 するだけなので害なし。

## 動作確認

- [ ] PR マージ後、`exec bash` で再読み込み → `which dpx4` が `commands/scripts/dpx4` を指す
- [ ] `dpx4 -h` で help が出る (container 停止中なら module 一覧無し)
- [ ] `dup all SITL_GZ_PX4` 起動中に `dpx4 commander status` で vehicle 状態が見える
- [ ] `dpx4 gz_bridge status` で Gazebo bridge 状態が見える
- [ ] `dpx4 listener vehicle_status` で uORB topic が dump される
- [ ] container 停止中に `dpx4 commander status` を叩くと ERROR で exit 1

## 関連

- project_drone2 Issue #81: SITL_GZ_PX4 で PX4 が motor command を出さない問題のデバッグで使う想定

🤖 Generated with [Claude Code](https://claude.com/claude-code)