### PR TITLE
chore: Isaac Sim ベースイメージを 6.0.0-dev3 に更新

### DIFF
--- a/dockerfiles/dockerfile.isaac_sim
+++ b/dockerfiles/dockerfile.isaac_sim
@@ -23,7 +23,7 @@
 # ベース OS: nvcr.io/nvidia/isaac-sim:6.0.0-dev2 は Ubuntu 24.04 (noble) 確認済み。
 #   → apt の jazzy(Python 3.12) がそのまま引け、Kit(3.12) と ABI 一致する。
 
-ARG ISAAC_IMAGE=nvcr.io/nvidia/isaac-sim:6.0.0-dev2
+ARG ISAAC_IMAGE=nvcr.io/nvidia/isaac-sim:6.0.0-dev3
 FROM ${ISAAC_IMAGE}
 
 ENV DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
## 概要

共通 Isaac Sim dockerfile のベースイメージを `nvcr.io/nvidia/isaac-sim:6.0.0-dev2` → `6.0.0-dev3` に更新。

## 変更点

- `dockerfiles/dockerfile.isaac_sim`: `ARG ISAAC_IMAGE` を `6.0.0-dev3` に bump

PR #23 (共通 Isaac Sim 6 + Jazzy dockerfile 集約) マージ後の追従更新。

🤖 Generated with [Claude Code](https://claude.com/claude-code)