### PR TITLE
feat: RID 一発変更コマンド setrid と dup の日次 RID 確認ゲート

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 *project_launch.service
 
 ############ Custom
+# RID 日次確認スタンプ (setrid / dup が生成。ホスト固有なので管理外)
+.acsl/
 *.pyc
 __pycache__
 *.bag

--- a/README.md
+++ b/README.md
@@ -181,6 +181,47 @@ commands/setup.sh を実行時にうまくいかないとき　systemd 関係の
 > journalctl -xeu project_launch.service
 ```
 
+## RID (ROS_DOMAIN_ID) の管理
+
+RID (`ROS_DOMAIN_ID`) は ROS2 の通信名前空間を分離する ID。**RID が混ざる (コンタミ) と、
+シミュレーション中のつもりが実験機に指令が飛び暴走する**等の重大事故につながる。
+そのため「**一人一つの RID** を持ち、シミュレーションでも実験でも必ず自分の RID を対象にする」運用とする。
+
+### RID を変える: `setrid <1-99>`
+
+```bash
+setrid 42      # ROS_DOMAIN_ID を 42 に変更 (1-99 の整数)
+```
+
+- `$ACSL_ROS2_DIR/bashrc` の `export ROS_DOMAIN_ID` を書き換え、以後の `dup` に反映。
+- 現在の対話シェルにも即 `export` され、プロンプト `[PROJECT<RID>]` の表示も更新される。
+- 実行すると「本日分の RID 確認」も同時に済んだ扱いになる。
+- `setrid` は (スクリプトでなく) `completions.sh` で定義されるシェル関数。
+  新しい端末では自動で有効。既存端末では `source ~/.bashrc` するか `dup` 再起動で読み込まれる。
+
+> **反映にはコンテナの再生成が必要。** RID はイメージに焼き込まれず `dup` 起動時にコンテナへ
+> 注入される。稼働中コンテナの RID を変えるには `drestart <name>` (= `drm` + `dup`)、
+> もしくは `drm <name> && dup <name>`。素の `docker restart` は旧 RID のまま起動するので不可。
+
+### 日次 RID 確認 (`dup` のゲート)
+
+`dup` は起動前に **1 日 1 回**、または RID が変わった直後に現在の RID を確認するプロンプトを出す。
+
+```
+========================== RID 確認 ==========================
+  PROJECT=rf   ROS_DOMAIN_ID=87
+  この RID(87) で起動してよいですか? [y/N]
+```
+
+- `y` で続行し `$ACSL_ROS2_DIR/.acsl/rid_confirmed` に `日付 RID` を記録。同日同 RID の以後の `dup` は無確認で続行。
+- それ以外は中断。`setrid <1-99>` で設定し直す。
+- 確認状態は `.acsl/rid_confirmed` で管理 (git 管理外)。日付か RID が変われば再確認。
+- 非対話実行 (systemd 自動起動 / CI) では `read` で固まらないよう自動スキップ。
+  一時的に無効化したいときは `DUP_SKIP_RID_CHECK=1 dup ...`。
+- さらに `dup` は、**呼び出し元シェルの `ROS_DOMAIN_ID` と設定ファイルの RID が食い違う**場合に
+  `recho` で警告する (別端末で `setrid` した後、手元シェルが古い RID のまま取り残されている等)。
+  `dup` 自体は常に設定ファイルの値で起動する。手元シェルを合わせるには `source $ACSL_ROS2_DIR/bashrc`。
+
 ## 開発の仕方
 このリポジトリを使ったシステム開発の手順
 **用語**

--- a/TODO.md
+++ b/TODO.md
@@ -89,7 +89,7 @@
 - READMEの名前変更 README_SYSTEM, README_DOCKER, README_ROSなど
 - humble化
 - IP 固定化
-- ROS_DOMAIN_IDの固定化
+- ~~ROS_DOMAIN_IDの固定化~~ → `setrid <1-99>` で変更 + `dup` 日次確認ゲートを実装 (README「RID (ROS_DOMAIN_ID) の管理」参照)
 - Command_list.txtを適切なファイルに統合し削除
 
 - 要確認

--- a/commands/completions.sh
+++ b/commands/completions.sh
@@ -15,3 +15,24 @@ _drm_completions() {
   fi
 }
 complete -F _drm_completions drm
+
+# setrid <1-99> : ROS_DOMAIN_ID(RID) を一発で変更する。
+#   - $ACSL_ROS2_DIR/bashrc の export 行を書き換え (以後の dup が反映)
+#   - 現在の対話シェルにも即 export (PS1 表示も更新)
+#   - 本日分の RID 確認スタンプも更新 (= setrid 自体が日次確認を兼ねる)
+# 関数で定義する理由: スクリプトだと親シェルの ROS_DOMAIN_ID を変えられないため。
+setrid() {
+  local id="$1"
+  if ! [[ "$id" =~ ^[0-9]+$ ]] || ((id < 1 || id > 99)); then
+    recho "setrid: RID は 1-99 の整数で指定してください (例: setrid 42)"
+    return 1
+  fi
+  # set_bashrc は CWD の ./bashrc を書き換えるのでサブシェルで $ACSL_ROS2_DIR へ移動
+  (cd "$ACSL_ROS2_DIR" && set_bashrc "export ROS_DOMAIN_ID" "$id" >/dev/null)
+  export ROS_DOMAIN_ID="$id"
+  local stamp="$ACSL_ROS2_DIR/.acsl/rid_confirmed"
+  mkdir -p "$(dirname "$stamp")"
+  printf '%s %s\n' "$(date +%F)" "$id" >"$stamp"
+  gecho "ROS_DOMAIN_ID を ${id} に設定しました (本日分の確認済み)。"
+  recho "反映には対象コンテナの再生成が必要: drestart <name> もしくは drm <name> && dup <name>"
+}

--- a/commands/scripts/dup
+++ b/commands/scripts/dup
@@ -3,6 +3,9 @@
 # Example :
 # dup acs tokyu debug : run tokyu project in debug mode
 # dup dev : simple up acsl-common:image_${PROJECT}
+# bashrc を source すると ROS_DOMAIN_ID がファイル値で上書きされるので、
+# RID 整合チェック用に「呼び出し元シェルが持っていた値」を先に退避する。
+_caller_rid="${ROS_DOMAIN_ID}"
 source $ACSL_ROS2_DIR/bashrc
 OPT=""
 if [[ "$1" == "-h" || "$1" == "--help" ]]; then
@@ -49,8 +52,48 @@ fi
 source $ACSL_ROS2_DIR/docker/common/scripts/super_echo
 source $ACSL_ROS2_DIR/bashrc
 
+# 呼び出し元シェルが持っていた RID と設定ファイル($ACSL_ROS2_DIR/bashrc)の RID が
+# 食い違っている場合に通知する。別端末で setrid した後など、手元シェルが古い RID の
+# まま取り残されているケースを検知する (dup 自体は常にファイル値で起動する)。
+if [ -n "$_caller_rid" ] && [ "$_caller_rid" != "$ROS_DOMAIN_ID" ]; then
+  recho "注意: このシェルの ROS_DOMAIN_ID(${_caller_rid}) と設定ファイルの RID(${ROS_DOMAIN_ID}) が異なります。"
+  recho "      dup は設定ファイルの ${ROS_DOMAIN_ID} で起動します。手元シェルを合わせる: source \$ACSL_ROS2_DIR/bashrc"
+fi
+
+# ===== RID 日次確認ゲート (実験機暴走防止) =====
+# 1 日 1 回、または RID が変わった直後に、起動前へ現在の ROS_DOMAIN_ID を確認させる。
+#   - 確認状態は $ACSL_ROS2_DIR/.acsl/rid_confirmed に "日付 RID" で保存
+#   - 非対話(systemd 自動起動 / CI)では read で固まらないようスキップ
+#   - DUP_SKIP_RID_CHECK=1 で明示的に無効化可
+#   - dup all 経由の連続 dup は、最初の確認でスタンプ更新済みのため 2 回目以降スキップ
+_rid_daily_gate() {
+  [ -t 0 ] || return 0
+  [ "${DUP_SKIP_RID_CHECK:-0}" = "1" ] && return 0
+  local stamp="$ACSL_ROS2_DIR/.acsl/rid_confirmed" today sd sr
+  today=$(date +%F)
+  [ -f "$stamp" ] && read -r sd sr _ <"$stamp"
+  if [ "$sd" = "$today" ] && [ "$sr" = "$ROS_DOMAIN_ID" ]; then
+    return 0
+  fi
+  recho "========================== RID 確認 =========================="
+  recho "  PROJECT=${PROJECT}   ROS_DOMAIN_ID=${ROS_DOMAIN_ID}"
+  recho "  RID コンタミによる実験機の暴走防止のため 1 日 1 回確認します。"
+  recho "  変更する場合は n で中断し  setrid <1-99>  を実行してください。"
+  local ans
+  read -r -p "  この RID(${ROS_DOMAIN_ID}) で起動してよいですか? [y/N] " ans
+  if [[ "$ans" =~ ^[Yy]$ ]]; then
+    mkdir -p "$(dirname "$stamp")"
+    printf '%s %s\n' "$today" "$ROS_DOMAIN_ID" >"$stamp"
+    gecho "  確認しました (RID=${ROS_DOMAIN_ID})。"
+  else
+    recho "  中断しました。setrid <1-99> で RID を設定し直してください。"
+    exit 1
+  fi
+}
+
 gecho "DUP ${ROS_DOMAIN_ID}: $OPT : $1 : ${@:2:($# - 1)}"
 if [ $# -ge 1 ]; then
+  _rid_daily_gate
   if [ $1 = "all" ]; then
     $ACSL_WORK_DIR/project_launch.sh ${@:2:($# - 1)}
   else

--- a/docker/common/scripts/setup_common.sh
+++ b/docker/common/scripts/setup_common.sh
@@ -2,7 +2,9 @@
 ########## Terminal Notice #######
 echo "source /common/scripts/super_echo" >>~/.bashrc
 ### ROS domain
-echo "recho ROS_DOMAIN_ID : $ROS_DOMAIN_ID" >>~/.bashrc
+# シングルクォートで遅延展開: din 時の実 env を表示する (restart で RID を変えても追従)。
+# entrypoint の "ROS_DOMAIN_ID で setup 済み判定" の grep にも文字列としてヒットする。
+echo 'recho ROS_DOMAIN_ID : $ROS_DOMAIN_ID' >>~/.bashrc
 
 # PATH
 echo "export PATH=/common/scripts:${PATH}" >>/root/.bashrc


### PR DESCRIPTION
## 背景 / 目的
実験・シミュレーションを行き来する際の **RID (`ROS_DOMAIN_ID`) コンタミ**によって、
シミュレーションのつもりが実験機に指令が飛び**暴走する重大事故**を防ぐ。
「一人一つの RID を持ち、シミュでも実験でも必ず自分の RID を対象にする」運用を、
(1) RID を簡便に変えられる仕組みと (2) 日次の確認で担保する。

## 変更内容
- **`setrid <1-99>`** (`commands/completions.sh` にシェル関数を追加)
  - `$ACSL_ROS2_DIR/bashrc` (= デプロイ先 `.acsl/bashrc` 同一) の `export ROS_DOMAIN_ID` を書換え
  - 現在の対話シェルにも即 `export`（プロンプト `[PROJECT<RID>]` も更新）
  - 本日分の確認スタンプも更新（setrid 自体が日次確認を兼ねる）
  - スクリプトでなく関数なのは、親シェルの env を変えるため
- **`dup` 日次 RID 確認ゲート** (`commands/scripts/dup`)
  - 1 日 1 回、または RID 変更直後に起動前へ `[y/N]` 確認。`.acsl/rid_confirmed` に `日付 RID` を記録
  - 同日同 RID は無確認で続行。`dup all` の連続 dup は初回確認後スキップ
  - 非対話 (systemd 自動起動 / CI) は `read` で固まらないよう自動スキップ。`DUP_SKIP_RID_CHECK=1` で無効化可
  - **呼び出し元シェルの RID と設定ファイルの RID が食い違う場合に `recho` 警告**（別端末で setrid 後など）
- **`setup_common.sh`**: din 時の RID お知らせを遅延展開にし、restart 後も実値を表示
- `.acsl/` を `.gitignore` に追加、`README.md`「RID (ROS_DOMAIN_ID) の管理」節追加、`TODO.md` の該当項目を消化

## 補足（仕様）
- RID はイメージに焼き込まれず `dup` 起動時にコンテナへ注入される（build-arg は `ROS_DISTRO`/`BASE_IMAGE` のみ）。
  反映には**コンテナ再生成**が必要: `drestart <name>` (= `drm`+`dup`) もしくは `drm && dup`。素の `docker restart` は不可。
- 再デプロイ (`acsl <type> <proj> <RID>`) 時は引数 RID で上書き（現挙動のまま）。

## 検証
- `setrid`: 範囲外拒否 / ファイル書換 / 現シェル即 export / スタンプ更新 をサンドボックスで確認
- 日次ゲート: 未確認→確認→記録 / 同日同RIDスキップ / RID変更・日付古で再確認 / skip env を確認
- 不一致通知: 手元≠ファイルで通知、一致・未設定で無通知 を確認
- `dup` / `completions.sh` / `setup_common.sh` の `bash -n` 構文チェック OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)