### PR TITLE
refactor: setrid を PATH 上スクリプト化

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,11 +193,13 @@ RID (`ROS_DOMAIN_ID`) は ROS2 の通信名前空間を分離する ID。**RID �
 setrid 42      # ROS_DOMAIN_ID を 42 に変更 (1-99 の整数)
 ```
 
-- `$ACSL_ROS2_DIR/bashrc` の `export ROS_DOMAIN_ID` を書き換え、以後の `dup` に反映。
-- 現在の対話シェルにも即 `export` され、プロンプト `[PROJECT<RID>]` の表示も更新される。
+- `$ACSL_ROS2_DIR/bashrc` の `export ROS_DOMAIN_ID` を書き換え、以後の `dup` / 新しいシェルに反映。
 - 実行すると「本日分の RID 確認」も同時に済んだ扱いになる。
-- `setrid` は (スクリプトでなく) `completions.sh` で定義されるシェル関数。
-  新しい端末では自動で有効。既存端末では `source ~/.bashrc` するか `dup` 再起動で読み込まれる。
+- `setrid` は `dup` 等と同じく `$ACSL_ROS2_DIR/commands/scripts/setrid` の **PATH 上スクリプト**。
+  ファイルが配置されていればどの端末でもそのまま使え、シェル関数のような再 `source` は不要。
+- ただしスクリプトは子プロセスなので**実行中の対話シェルの `ROS_DOMAIN_ID` は変えられない**
+  (永続化は設定ファイルで完結)。手元シェルとプロンプト `[PROJECT<RID>]` 表示に即反映したい場合は
+  `source $ACSL_ROS2_DIR/bashrc`(`dup` の RID 不一致警告と同じ案内)。`dup` は常に設定ファイルの値で起動する。
 
 > **反映にはコンテナの再生成が必要。** RID はイメージに焼き込まれず `dup` 起動時にコンテナへ
 > 注入される。稼働中コンテナの RID を変えるには `drestart <name>` (= `drm` + `dup`)、

--- a/commands/completions.sh
+++ b/commands/completions.sh
@@ -16,23 +16,5 @@ _drm_completions() {
 }
 complete -F _drm_completions drm
 
-# setrid <1-99> : ROS_DOMAIN_ID(RID) を一発で変更する。
-#   - $ACSL_ROS2_DIR/bashrc の export 行を書き換え (以後の dup が反映)
-#   - 現在の対話シェルにも即 export (PS1 表示も更新)
-#   - 本日分の RID 確認スタンプも更新 (= setrid 自体が日次確認を兼ねる)
-# 関数で定義する理由: スクリプトだと親シェルの ROS_DOMAIN_ID を変えられないため。
-setrid() {
-  local id="$1"
-  if ! [[ "$id" =~ ^[0-9]+$ ]] || ((id < 1 || id > 99)); then
-    recho "setrid: RID は 1-99 の整数で指定してください (例: setrid 42)"
-    return 1
-  fi
-  # set_bashrc は CWD の ./bashrc を書き換えるのでサブシェルで $ACSL_ROS2_DIR へ移動
-  (cd "$ACSL_ROS2_DIR" && set_bashrc "export ROS_DOMAIN_ID" "$id" >/dev/null)
-  export ROS_DOMAIN_ID="$id"
-  local stamp="$ACSL_ROS2_DIR/.acsl/rid_confirmed"
-  mkdir -p "$(dirname "$stamp")"
-  printf '%s %s\n' "$(date +%F)" "$id" >"$stamp"
-  gecho "ROS_DOMAIN_ID を ${id} に設定しました (本日分の確認済み)。"
-  recho "反映には対象コンテナの再生成が必要: drestart <name> もしくは drm <name> && dup <name>"
-}
+# setrid <1-99> は $ACSL_ROS2_DIR/commands/scripts/setrid のスクリプトに移動
+# (dup 等と同じく PATH 上のコマンド)。シェル関数ではないので再 source 不要。

--- a/commands/scripts/setrid
+++ b/commands/scripts/setrid
@@ -1,0 +1,32 @@
+#! /usr/bin/bash
+# setrid <1-99> : ROS_DOMAIN_ID(RID) を一発で変更するコマンド。
+#   dup / dps 等と同じく $ACSL_ROS2_DIR/commands/scripts 配下の PATH 上スクリプト。
+#   - $ACSL_ROS2_DIR/bashrc の export ROS_DOMAIN_ID 行を書き換え (以後の dup / 新シェルに反映)
+#   - 本日分の RID 確認スタンプ ($ACSL_ROS2_DIR/.acsl/rid_confirmed) も更新
+#     (= setrid 自体が日次確認を兼ねる)
+#
+# 注意: スクリプトは子プロセスのため、実行中の対話シェルの ROS_DOMAIN_ID は変えられない
+#       (export は親シェルに伝播しない)。手元シェルへ即反映したい場合は最後に案内する
+#       source コマンドを実行する。dup は常に設定ファイルの値で起動するため、永続化は
+#       このスクリプトで完結している。
+
+source "$ACSL_ROS2_DIR/docker/common/scripts/super_echo"
+
+id="$1"
+if ! [[ "$id" =~ ^[0-9]+$ ]] || ((id < 1 || id > 99)); then
+  recho "setrid: RID は 1-99 の整数で指定してください (例: setrid 42)"
+  exit 1
+fi
+
+# set_bashrc は CWD の ./bashrc を書き換えるので $ACSL_ROS2_DIR へ移動して実行
+(cd "$ACSL_ROS2_DIR" && set_bashrc "export ROS_DOMAIN_ID" "$id" >/dev/null)
+
+stamp="$ACSL_ROS2_DIR/.acsl/rid_confirmed"
+mkdir -p "$(dirname "$stamp")"
+printf '%s %s\n' "$(date +%F)" "$id" >"$stamp"
+
+gecho "ROS_DOMAIN_ID を ${id} に設定しました (本日分の確認済み)。"
+if [ -n "$ROS_DOMAIN_ID" ] && [ "$ROS_DOMAIN_ID" != "$id" ]; then
+  recho "このシェルは RID=${ROS_DOMAIN_ID} のままです。即反映: source \$ACSL_ROS2_DIR/bashrc"
+fi
+recho "稼働中コンテナへの反映には再生成が必要: drestart <name> もしくは drm <name> && dup <name>"


### PR DESCRIPTION
## 概要

`setrid <1-99>`(ROS_DOMAIN_ID 変更コマンド)を `completions.sh` のシェル関数から、`dup`/`dps` と同じ `commands/scripts/` 配下の**実体スクリプト**に移動。

PR #25 で導入した setrid は関数定義だったため、既存端末では `source` し直さないと反映されず使いづらかった。PATH 上のスクリプトにすることで、**ファイルが配置されればどの端末でもそのまま使え、再 source が不要**になる(`commands/scripts` は host setup・rover/drone の `.acsl/bashrc` 双方で PATH に通っている)。

## 変更点

- `commands/scripts/setrid`(新規, +x):バリデーション → `$ACSL_ROS2_DIR/bashrc` の `export ROS_DOMAIN_ID` 書き換え → 日次確認スタンプ更新。
- `commands/completions.sh`:`setrid()` 関数定義を削除し、移動先ポインタコメントのみ残す。
- `README.md`:「シェル関数」→「PATH 上スクリプト」に記述更新。

## 挙動の変更点(注意)

スクリプトは子プロセスのため、**実行中の対話シェルの `ROS_DOMAIN_ID` を即 export できない**(関数化していた元々の理由)。

- 永続化(設定ファイル書き換え)・日次確認スタンプはスクリプトで完結 → 次の `dup` / 新シェルは正しい RID で動作。
- 手元シェル＆プロンプト `[PROJECT<RID>]` 表示への即反映は `source $ACSL_ROS2_DIR/bashrc`(`dup` の RID 不一致警告が元々案内している方法と同一)。現在シェルが古い RID のままなら setrid 実行時にこの案内を表示する。

## テスト

ローカルで仮 `$ACSL_ROS2_DIR` を用意し確認:
- 異常系 `setrid 0` / `setrid abc` → エラー終了(exit 1)
- 正常系 `setrid 42` → bashrc `5 → 42`、スタンプ記録、現在シェル stale 案内表示
- 既存値置換 `setrid 7` → `42 → 7`

🤖 Generated with [Claude Code](https://claude.com/claude-code)