### PR TITLE
feat: dup の第2引数タブ補完 + dup -h <name> をサブコマンド一覧化

### DIFF
--- a/commands/completions.sh
+++ b/commands/completions.sh
@@ -1,8 +1,50 @@
+# dup <target> の launcher (.sh) を解決する。
+#   all → project_launch.sh / それ以外 → launcher/launch_<target>.sh
+# 完全一致を優先し、無ければ dup 本体と同じ grep フォールバック (最後にマッチ) を使う。
+_dup_resolve_launcher() {
+  local target="$1"
+  if [[ "$target" == "all" ]]; then
+    [[ -f "${ACSL_WORK_DIR}/project_launch.sh" ]] && echo "${ACSL_WORK_DIR}/project_launch.sh"
+    return
+  fi
+  if [[ -f "${ACSL_WORK_DIR}/launcher/launch_${target}.sh" ]]; then
+    echo "${ACSL_WORK_DIR}/launcher/launch_${target}.sh"
+    return
+  fi
+  local m
+  m=$(ls -v "${ACSL_WORK_DIR}/launcher/" 2>/dev/null | grep "launch_${target}" | grep '\.sh$' | tail -1)
+  [[ -n "$m" ]] && echo "${ACSL_WORK_DIR}/launcher/${m}"
+}
+
+# launcher の「トップレベル case "$1" in」の pattern (= サブコマンド) を列挙する。
+# ネストした case (use_sim_time 判定等) の pattern は深さで除外する。
+_dup_subcommands() {
+  awk '
+    !cap && $0 ~ /(^|[[:space:]])case[[:space:]]+"?\$(\{?1\}?)"?[[:space:]]+in([[:space:]]|$)/ { cap=1; depth=1; next }
+    cap {
+      if ($0 ~ /(^|[[:space:]])case[[:space:]].*[[:space:]]in([[:space:]]|$)/) { depth++; next }
+      if ($0 ~ /(^|[[:space:]])esac([[:space:]]|;|$)/) { depth--; if (depth==0) cap=0; next }
+      if (depth==1 && match($0, /^[[:space:]]*"?[A-Za-z0-9_:=.-]+("?\|"?[A-Za-z0-9_:=.-]+)*"?\)/)) {
+        line=$0; sub(/\).*/,"",line); gsub(/[[:space:]"]/,"",line)
+        n=split(line, a, "|"); for(i=1;i<=n;i++) if(a[i]!="*"&&a[i]!="") print a[i]
+      }
+    }
+  ' "$1"
+}
+
 _dup_completions() {
+  local cur="${COMP_WORDS[COMP_CWORD]}"
   if [[ $COMP_CWORD -eq 1 ]]; then
     local launchers
     launchers=$(ls "${ACSL_WORK_DIR}/launcher/" 2>/dev/null | sed -n 's/^launch_\(.*\)\.sh$/\1/p')
-    COMPREPLY=($(compgen -W "all dev $launchers" -- "${COMP_WORDS[1]}"))
+    COMPREPLY=($(compgen -W "all dev $launchers" -- "$cur"))
+  elif [[ $COMP_CWORD -eq 2 ]]; then
+    # dup <target> <TAB> : launcher/project_launch.sh の case "$1" pattern を提示
+    local launcher subs
+    launcher=$(_dup_resolve_launcher "${COMP_WORDS[1]}")
+    [[ -n "$launcher" && -f "$launcher" ]] || return 0
+    subs=$(_dup_subcommands "$launcher")
+    COMPREPLY=($(compgen -W "$subs" -- "$cur"))
   fi
 }
 complete -F _dup_completions dup

--- a/commands/scripts/dup
+++ b/commands/scripts/dup
@@ -26,12 +26,39 @@ if [[ "$1" == "-h" || "$1" == "--help" ]]; then
     echo "Set DUP_NO_AUTOBUILD=1 to disable step 2 (CI / offline use)."
     exit 0
   fi
-  ROS_LAUNCH=$(ls -v $ACSL_WORK_DIR/launcher/ 2>/dev/null | grep launch_$2 | fmt | awk '{print $NF}')
-  if [[ -n "$ROS_LAUNCH" ]]; then
-    $ACSL_WORK_DIR/launcher/$ROS_LAUNCH -h
+  # launcher を解決 (all → project_launch.sh / それ以外 → launch_<name>.sh)。
+  # 旧実装は launcher を -h 付きでホスト実行していたが、launcher に -h case が
+  # 無く *) に落ちてホスト上で ros2 run してしまうため廃止。代わりに
+  # トップレベル case "$1" の pattern (= サブコマンド) を列挙し、本文を cat する。
+  target="$2"
+  if [[ "$target" == "all" ]]; then
+    launcher="$ACSL_WORK_DIR/project_launch.sh"
+  elif [[ -f "$ACSL_WORK_DIR/launcher/launch_${target}.sh" ]]; then
+    launcher="$ACSL_WORK_DIR/launcher/launch_${target}.sh"
   else
-    echo "Launcher not found for '$2'"
+    ROS_LAUNCH=$(ls -v $ACSL_WORK_DIR/launcher/ 2>/dev/null | grep "launch_${target}" | grep '\.sh$' | tail -1)
+    [[ -n "$ROS_LAUNCH" ]] && launcher="$ACSL_WORK_DIR/launcher/$ROS_LAUNCH"
   fi
+  if [[ -z "$launcher" || ! -f "$launcher" ]]; then
+    echo "Launcher not found for '$target'"
+    exit 1
+  fi
+  echo "Launcher: $launcher"
+  echo "Subcommands (case \$1 patterns):"
+  awk '
+    !cap && $0 ~ /(^|[[:space:]])case[[:space:]]+"?\$(\{?1\}?)"?[[:space:]]+in([[:space:]]|$)/ { cap=1; depth=1; next }
+    cap {
+      if ($0 ~ /(^|[[:space:]])case[[:space:]].*[[:space:]]in([[:space:]]|$)/) { depth++; next }
+      if ($0 ~ /(^|[[:space:]])esac([[:space:]]|;|$)/) { depth--; if (depth==0) cap=0; next }
+      if (depth==1 && match($0, /^[[:space:]]*"?[A-Za-z0-9_:=.-]+("?\|"?[A-Za-z0-9_:=.-]+)*"?\)/)) {
+        line=$0; sub(/\).*/,"",line); gsub(/[[:space:]"]/,"",line)
+        n=split(line, a, "|"); for(i=1;i<=n;i++) if(a[i]!="*"&&a[i]!="") print a[i]
+      }
+    }
+  ' "$launcher" | sed 's/^/  /'
+  echo ""
+  echo "----- $(basename "$launcher") -----"
+  cat "$launcher"
   exit 0
 fi
 if [[ "$1" =~ ^--image= ]]; then


### PR DESCRIPTION
## 概要
`dup` の使い勝手向上。launcher を見に行かずとも、どのサブコマンドが取れるかを
タブ補完／`dup -h` で確認できるようにする。

## 変更点
### 1. `dup <target> <TAB>` 第2引数補完 (`commands/completions.sh`)
- `dup <target> <TAB>` で、対象 launcher (`launcher/launch_<target>.sh`、
  `all` は `project_launch.sh`) のトップレベル `case "$1" in` pattern を提示。
- ネストした `case` (use_sim_time 判定や node_capture 内の clock 判定等) の
  pattern は深さ管理で除外するため、`true`/`false`/数値などのノイズは出ない。
- 第1引数補完 (`dup <TAB>` → launcher 一覧 / all / dev) は既存のまま。

確認例:
- `dup rover <TAB>` → `matlab kill set_target hb node_capture DEBUG sitl sim`
- `dup all <TAB>`   → `SIM EXP_PX4 EXP_AP EXP_ESP32 SITL_PX4 SITL_GZ_PX4 SITL_AP SITL_GZ_AP SITL_OMNI`
- `dup nav2 <TAB>`  → `save_map slam localization rviz2 map_only`

### 2. `dup -h <name>` の修正 (`commands/scripts/dup`)
- **旧実装の不具合**: `launcher/launch_<name>.sh -h` を**ホスト上で実行**して
  いたが、launcher 側に `-h` の case が無いため `*)` に落ち、ホスト上で
  `ros2 run ...` を起動してしまっていた（壊れていた）。
- **修正後**: launcher を実行せず、トップレベル `case "$1"` の pattern
  (= サブコマンド) を列挙し、本文を `cat` する安全な help に変更。
  `dup -h all` は `project_launch.sh` を対象にする。

## デプロイ
`completions.sh` は `.bashrc` から source される (`setup_bashrc` 経由)。
`.acsl` はリポジトリの複製のため、本 PR マージ後に各ホストの
`~/<proj>/.acsl/commands/{completions.sh,scripts/dup}` を更新し、シェルを
開き直す (または `source ~/<proj>/.acsl/commands/completions.sh`) 必要がある。
※ 動作確認のため `~/drone` `~/rover` のデプロイ済みコピーは先行更新済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)