### PR TITLE
refactor: promote environment out of isaac_sim to project root

### DIFF
--- a/commands/scripts/gpush
+++ b/commands/scripts/gpush
@@ -27,7 +27,7 @@ sed -i "s|\$ACSL_ROS2_DIR|$ACSL_ROS2_DIR|g" $ACSL_WORK_DIR/project_launch*.sh
 git push
 
 # clone済み環境リポジトリ
-for env_dir in $ACSL_WORK_DIR/isaac_sim/environments/*/; do
+for env_dir in $ACSL_WORK_DIR/environments/*/; do
   if [[ -d "${env_dir}.git" ]]; then
     changes=$(git -C "$env_dir" status --porcelain)
     if [[ -n "$changes" ]]; then

--- a/docker/common/scripts/gpull
+++ b/docker/common/scripts/gpull
@@ -61,7 +61,7 @@ else
   fi
 
   # clone済み環境リポジトリを更新
-  for env_dir in $ACSL_WORK_DIR/isaac_sim/environments/*/; do
+  for env_dir in $ACSL_WORK_DIR/environments/*/; do
     if [[ -d "${env_dir}.git" ]]; then
       echo "gpull environment: ${env_dir}"
       git -C "$env_dir" pull

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -71,12 +71,15 @@ services:
       - ./common:/common # common scripts
       - $ACSL_WORK_DIR/launcher:/common/ros_launcher
       # 建屋 environment を 1 本の親マウントで全コンテナにライブ配送 (複数建屋対応)
+      #   ホスト $ACSL_WORK_DIR/environments/<name> → コンテナ /root/environment/<name>
+      #   environment は backend 非依存の共通資産なのでプロジェクト直下に置く
+      #   (SITL/HITL/実機すべての制御ランタイムが config/occupancy/maps を参照する)。
       #   /root/environment/<name>/{config,occupancy,omni,...}
       # rw: node_capture / save_map / serialize がコンテナから書く
-      - $ACSL_WORK_DIR/isaac_sim/environments:/root/environment
+      - $ACSL_WORK_DIR/environments:/root/environment
       # 占有格子は active 建屋の occupancy を /common/occupancy にも別名 bind
       # (launch_slam_toolbox.sh / launch_nav2.sh を無改修で建屋切替できるよう ENV_BUILDING で切替)
-      - $ACSL_WORK_DIR/isaac_sim/environments/${ENV_BUILDING:-bld10}/occupancy:/common/occupancy
+      - $ACSL_WORK_DIR/environments/${ENV_BUILDING:-bld10}/occupancy:/common/occupancy
       - /dev:/dev # GPIO and USB devices
       - vscode-server:/root/.vscode-server # VScode setting (preserve VScode extension)
       - $ACSL_WORK_DIR/packages:/root/ros2_ws/src/ros_packages


### PR DESCRIPTION
## 背景
建屋 `environment` は SITL/HITL/実機すべての制御ランタイム (building_reference, nav2 occupancy 等) が参照する **backend 非依存の共通資産**であり、Isaac Sim 専用ではない。しかしホスト側の物理配置が `isaac_sim/environments/` 配下にあるため、あたかも Isaac Sim 限定資産のように見えていた。コンテナ側は既に `/root/environment` という top-level の正しいメンタルモデルになっており、ホスト配置だけが取り残されていた。

## 変更
ホストの clone 先・マウント元を `$ACSL_WORK_DIR/isaac_sim/environments` → `$ACSL_WORK_DIR/environments` へ格上げ。コンテナ側 target (`/root/environment`) は据え置き。

- `docker/docker-compose.yml`: 親マウント元と occupancy 別名マウント元 (+意図コメント)
- `commands/scripts/gpush`, `docker/common/scripts/gpull`: env ループのパス

## 連動 PR (要 merge 順)
この基盤変更に追従して両 project のデプロイ/参照を更新:
- acsl-tcu/project_rf_rover#refactor/promote-environment
- acsl-tcu/project_drone2#refactor/promote-environment

## ⚠️ デプロイ移行
既存デプロイは一度だけ `mv isaac_sim/environments environments`（または `./setup` で再 clone）が必要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)