### PR TITLE
feat(dup): compose override を dockerfiles/ でも探す

### DIFF
--- a/commands/scripts/dup
+++ b/commands/scripts/dup
@@ -66,14 +66,19 @@ if [[ "$1" =~ ^--image= ]]; then
   shift
 fi
 compose=" -f ${ACSL_ROS2_DIR}/docker/docker-compose.yml "
-# project 固有の docker-compose 上書きは必ず $ACSL_WORK_DIR から探す。
-# dup all 経由で project_launch.sh が cd した後でも検出できるように
+# project 固有の docker-compose 上書きを探す。dockerfile.<name> と同様に
+# dockerfiles/ → ルート の順で探索する (ルートは後方互換)。
+# dup all 経由で project_launch.sh が cd した後でも検出できるよう
 # CWD ではなく ACSL_WORK_DIR を使う。
-if [[ -f "${ACSL_WORK_DIR}/docker-compose_${1}.yml" ]]; then
-  compose=${compose}" -f ${ACSL_WORK_DIR}/docker-compose_${1}.yml "
-  echo ":::::::::::::::::::::::::::::"
-  echo ${compose}
-fi
+for ov in "${ACSL_WORK_DIR}/dockerfiles/docker-compose_${1}.yml" \
+          "${ACSL_WORK_DIR}/docker-compose_${1}.yml"; do
+  if [[ -f "$ov" ]]; then
+    compose=${compose}" -f ${ov} "
+    echo ":::::::::::::::::::::::::::::"
+    echo ${compose}
+    break
+  fi
+done
 
 #cd $ACSL_ROS2_DIR/docker
 source $ACSL_ROS2_DIR/docker/common/scripts/super_echo


### PR DESCRIPTION
## 目的
project 固有の docker-compose 上書き (`docker-compose_<name>.yml`) を、`dockerfile.<name>` の探索と同じく **`dockerfiles/` → ルート** の順で探せるようにする。これで build 定義 (`dockerfiles/dockerfile.<name>`) と runtime override (`dockerfiles/docker-compose_<name>.yml`) を `dockerfiles/` に並べられ、ルート直下が散らからない。

## 変更
`commands/scripts/dup` の compose override 検出のみ:

```diff
-if [[ -f "${ACSL_WORK_DIR}/docker-compose_${1}.yml" ]]; then
-  compose=${compose}" -f ${ACSL_WORK_DIR}/docker-compose_${1}.yml "
-  ...
-fi
+for ov in "${ACSL_WORK_DIR}/dockerfiles/docker-compose_${1}.yml" \
+          "${ACSL_WORK_DIR}/docker-compose_${1}.yml"; do
+  if [[ -f "$ov" ]]; then
+    compose=${compose}" -f ${ov} "
+    ...
+    break
+  fi
+done
```

## ポイント
- `dockerfile.<name>` 探索 (`dockerfiles/` を見る流儀) と一貫。
- **後方互換**: ルート直下も引き続き探すので、既存の `docker-compose_*.yml` は壊れない。
- 影響範囲は compose override 検出のみ。GPU 付与など他ロジックは不変。`bash -n` 通過。

## 連動 (follow-up)
rover 側で `docker-compose_yolo.yml` を `dockerfiles/` へ移動する PR を用意予定。
**この PR を先に land** してから rover 側を merge する (順序を逆にすると、デプロイ済み `dup` がルートしか見ず `dup yolo` の GPU override が外れるため)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
