### PR TITLE
docs: acsl_interfaces README のリンク切れ修正 (RcChannels.msg → Rc.msg)

### DIFF
--- a/packages/acsl_interfaces/README.md
+++ b/packages/acsl_interfaces/README.md
@@ -8,4 +8,4 @@
 | [EscTelemetry1To4.msg](./msg/EscTelemetry1To4.msg) | ESCの電圧，回転数などのデータを格納する型 |
 | [Heartbeat.msg](./msg/Heartbeat.msg)               | FCUのバージョンなどを格納する型 |
 | [Mav.msg](./msg/Mav.msg)                           | FCUの制御モード，Arm状況などを格納する型 |
-| [RcChannels.msg](./msg/RcChannels.msg)             | プロポの信号状況を格納する型 |
+| [Rc.msg](./msg/Rc.msg)                             | プロポの信号状況を格納する型 |


### PR DESCRIPTION
## 発見 (nightly-audit / docs-drift テーマの初回試走)
`packages/acsl_interfaces/README.md` のメッセージ一覧で `RcChannels.msg` をリンクしているが、実体は `Rc.msg` にリネーム済みでファイルが存在しない (リンク切れ)。

## 証拠
- `packages/acsl_interfaces/msg/` に `RcChannels.msg` は無く `Rc.msg` がある。
- `Rc.msg` の中身 (`port` / `rssi` / `chancount` / `signals[]`) は README の説明「プロポの信号状況を格納する型」と一致 → 同一メッセージのリネームと断定でき、修正先が一意。

## 修正
README:11 のリンクと表示名を `Rc.msg` / `./msg/Rc.msg` に追従 (実装は不変、ドキュメントのみ)。

## どう検証したか
- `ls packages/acsl_interfaces/msg/Rc.msg` で実在確認。
- `grep RcChannels README.md` で残存ゼロ確認。

## 確信度
高 (リネーム取り残しが明確、修正先が一意)。

## 補足 (この PR では直さない・要相談)
README は msg/ 実体 9 個のうち 5 個しか列挙しておらず `CommandLong/FC/MavParam/MoterTest` が未記載。これは「リンク切れの追従」ではなく内容追加なので docs-drift の自動修正スコープ外。別途判断を。

---
🤖 夜間自動監査 (docs-drift) が生成。merge 前にレビューしてください。
