### PR TITLE
feat: docker-compose に FastDDS Discovery Server 用環境変数を追加

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -48,6 +48,9 @@ services:
       - TAG=${TAG:-image_${PROJECT}}
       - HOST_USER=$LOGNAME # deprecate 
       - ROS_DOMAIN_ID=${ROS_DOMAIN_ID} # set project unique id
+      # FastDDS Discovery Server (ユニキャスト discovery)。既定は空 = 従来どおりマルチキャスト discovery
+      - ROS_DISCOVERY_SERVER=${ROS_DISCOVERY_SERVER:-}
+      - ROS_SUPER_CLIENT=${ROS_SUPER_CLIENT:-}
       - USER=$USER
       - ACSL_ROS2_DIR=$ACSL_ROS2_DIR
       - ACSL_WORK_DIR=$ACSL_WORK_DIR


### PR DESCRIPTION
## やったこと
- `docker/docker-compose.yml` の `common` サービスに `ROS_DISCOVERY_SERVER` / `ROS_SUPER_CLIENT` 環境変数を追加し、ホスト側の値をコンテナへ引き継げるようにした。

## やっていないこと
- Discovery Server 自体の起動・運用手順のドキュメント化。

## できるようになったこと
- ホスト側で `ROS_DISCOVERY_SERVER` を設定すれば、FastDDS のユニキャスト discovery（Discovery Server）をコンテナ内 ROS2 ノードに適用できる。

## デグレード
- なし。既定値は空（`:-`）のため、未設定なら従来どおりマルチキャスト discovery で動作する。

## テスト・動作確認
- 変数追加のみ。既定空のため既存挙動に影響なし（構文確認済み）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)