### PR TITLE
chore: Isaac Sim ベースイメージを 6.0.1 に更新

### DIFF
--- a/dockerfiles/dockerfile.isaac_sim
+++ b/dockerfiles/dockerfile.isaac_sim
@@ -23,7 +23,7 @@
 # ベース OS: nvcr.io/nvidia/isaac-sim:6.0.0-dev2 は Ubuntu 24.04 (noble) 確認済み。
 #   → apt の jazzy(Python 3.12) がそのまま引け、Kit(3.12) と ABI 一致する。
 
-ARG ISAAC_IMAGE=nvcr.io/nvidia/isaac-sim:6.0.0-dev3
+ARG ISAAC_IMAGE=nvcr.io/nvidia/isaac-sim:6.0.1
 FROM ${ISAAC_IMAGE}
 
 ENV DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
## 概要
`dockerfiles/dockerfile.isaac_sim` の `ISAAC_IMAGE` を `nvcr.io/nvidia/isaac-sim:6.0.0-dev3` → `6.0.1`（安定版）に更新。

元々 `feat/nightly-audit-agent` ブランチに誤ってコミット (`f895928`) されていた変更を、本来の行き先である main へ cherry-pick で切り出したもの。誤コミットは feat/nightly-audit-agent から除去済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)