### PR TITLE
feat(nightly-audit): Slack からの制御 (poll型 curl ボット)

### DIFF
--- a/nightly_audit/README.md
+++ b/nightly_audit/README.md
@@ -78,6 +78,26 @@ md レポートはプル型で気づけないので、完了後にハーネス�
 - bot token + `chat.postMessage` で動的にチャンネルを選ぶ方式も可能だが、固定チャンネルなら
   webhook が最小構成。`run_nightly_audit.sh` の `notify_slack()` を差し替えれば対応できる。
 
+### 🎛️ Slack からの操作 (任意・双方向)
+webhook は送信専用。Slack から**コマンドを送る**には受信経路が要る。`slack_control.sh` は
+NAT 内・pip 無しでも動く **poll 型ボット** (curl+jq で制御チャンネルを ~15 秒間隔で取得し
+`!audit <cmd>` を実行)。
+- **セットアップ**:
+  1. Slack App に **Bot Token Scopes** `channels:history` (公開) か `groups:history` (非公開) と
+     `chat:write` を付与し、ワークスペースにインストール → **Bot User OAuth Token** (`xoxb-`) を取得。
+  2. 制御チャンネルに bot を招待し、**チャンネル ID** (`C...`) を控える。
+  3. 自分の **Slack user ID** (`U...`) を控える (実行系コマンドの allowlist 用)。
+  4. env (`~/.config/acsl-nightly-audit.env`) に設定:
+     `NIGHTLY_SLACK_BOT_TOKEN` / `NIGHTLY_SLACK_CONTROL_CHANNEL` / `NIGHTLY_SLACK_ALLOW_USERS`。
+  5. 常駐: `slack_control.service` を `~/.config/systemd/user/` に置き
+     `loginctl enable-linger $USER && systemctl --user enable --now slack_control`
+     (お試しは `./slack_control.sh` を前景実行)。
+- **コマンド** (チャンネルに投稿):
+  `!audit list` / `!audit status` / `!audit enable <theme>` / `!audit disable <theme>` / `!audit run <theme>`。
+- **安全**: `enable/disable/run` は `NIGHTLY_SLACK_ALLOW_USERS` のユーザーのみ (未設定だと実行系は無効、
+  閲覧のみ)。`run` が起動する監査は通常どおり `audit_settings.json` の deny ハードガード下で走るため、
+  EXP/force-push/main push/`rm -rf` 等はボット経由でも不可。多重起動は runner の flock が防ぐ。
+
 ### ⛔ 実機安全 (絶対)
 **この cron は実機に触れない。アクチュエーション (モーター/プロペラ/車輪) を伴う一切をしない。**
 - backend-smoke で動かすのは **SIM / SITL (純ソフトウェア)** のみ。**HITL は受動検証まで**

--- a/nightly_audit/install_cron.sh
+++ b/nightly_audit/install_cron.sh
@@ -35,12 +35,19 @@ if [[ ! -f "$ENV_FILE" ]]; then
 # Slack 通知 (任意。設定すると完了後に要約を指定チャンネルへ投稿。未設定なら無効):
 #   NIGHTLY_SLACK_WEBHOOK=https://hooks.slack.com/services/XXX/YYY/ZZZ  # Incoming Webhook URL
 #   NIGHTLY_SLACK_NOTIFY=always   # always(既定) | on-change (PR/要相談/異常時のみ)
+# Slack 制御ボット (任意。slack_control.sh / slack_control.service 用。Slack からコマンド):
+#   NIGHTLY_SLACK_BOT_TOKEN=xoxb-...        # Bot token (scopes: channels:history|groups:history, chat:write)
+#   NIGHTLY_SLACK_CONTROL_CHANNEL=C0123...  # 制御チャンネル ID (bot を招待しておく)
+#   NIGHTLY_SLACK_ALLOW_USERS=U001,U002     # enable/disable/run を許可する Slack user ID (未設定だと実行系は無効)
 export HOME="$HOME"
 export ACSL_WORK_DIR="${ACSL_WORK_DIR:-$HOME}"
 # export CLAUDE_CODE_OAUTH_TOKEN=
 # export GH_TOKEN=
 # export NIGHTLY_SLACK_WEBHOOK=
 # export NIGHTLY_SLACK_NOTIFY=always
+# export NIGHTLY_SLACK_BOT_TOKEN=
+# export NIGHTLY_SLACK_CONTROL_CHANNEL=
+# export NIGHTLY_SLACK_ALLOW_USERS=
 EOF
   chmod 600 "$ENV_FILE"
   echo "env 雛形を作成: $ENV_FILE (トークンを記入してから cron が機能します)"

--- a/nightly_audit/slack_control.service
+++ b/nightly_audit/slack_control.service
@@ -1,0 +1,25 @@
+# acsl nightly-audit Slack 制御ボット (poll型) の systemd user service。
+# 設置:
+#   mkdir -p ~/.config/systemd/user
+#   cp nightly_audit/slack_control.service ~/.config/systemd/user/
+#   # ↓ ExecStart 内のリポパスが ~/GitHub/sb/acsl_infra でない場合は編集する
+#   loginctl enable-linger "$USER"          # ログアウトしても常駐させる
+#   systemctl --user daemon-reload
+#   systemctl --user enable --now slack_control
+#   journalctl --user -u slack_control -f    # ログ確認
+#
+# env ファイルは `export VAR=...` 形式 (systemd の EnvironmentFile は export を解さない)
+# なので、bash -lc で source してから起動する。
+[Unit]
+Description=acsl nightly-audit Slack control bot (poll)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=/bin/bash -lc '. "%h/.config/acsl-nightly-audit.env"; exec "%h/GitHub/sb/acsl_infra/nightly_audit/slack_control.sh"'
+Restart=always
+RestartSec=10
+
+[Install]
+WantedBy=default.target

--- a/nightly_audit/slack_control.sh
+++ b/nightly_audit/slack_control.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+# Slack 制御ボット (poll 型)。制御チャンネルを定期取得し `!audit <cmd>` を実行する。
+# webhook(送信専用)とは別の「Slack → ホスト」受信経路。NAT 内・pip 無しでも動くよう
+# curl + jq だけで実装 (公開エンドポイント/WebSocket/外部パッケージ不要)。
+#
+# 必要 env (systemd/cron が ~/.config/acsl-nightly-audit.env を source して渡す):
+#   NIGHTLY_SLACK_BOT_TOKEN        xoxb-...   (scopes: channels:history か groups:history, chat:write)
+#   NIGHTLY_SLACK_CONTROL_CHANNEL  C0123...   (この channel に bot を招待しておく)
+#   NIGHTLY_SLACK_ALLOW_USERS      U001,U002  (実行系コマンドを許可する Slack user ID。未設定だと実行系は無効)
+#   NIGHTLY_SLACK_POLL_SEC         既定 15
+#
+# 実行系 (run) は run_nightly_audit.sh を起動するので、claude/gh トークンも env に必要。
+# 完了通知は run 側の notify_slack (webhook) が出す。多重起動は runner の flock が防ぐ。
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROTATION="$HERE/rotation.txt"
+THEMES_DIR="$HERE/themes"
+RUNNER="$HERE/run_nightly_audit.sh"
+LOG_DIR="$HERE/logs"; mkdir -p "$LOG_DIR"
+STATE="$LOG_DIR/.slack_control.last_ts"
+
+BOT="${NIGHTLY_SLACK_BOT_TOKEN:-}"
+CH="${NIGHTLY_SLACK_CONTROL_CHANNEL:-}"
+ALLOW="${NIGHTLY_SLACK_ALLOW_USERS:-}"
+POLL="${NIGHTLY_SLACK_POLL_SEC:-15}"
+
+[[ -z "$BOT" || -z "$CH" ]] && {
+  echo "[ctl] NIGHTLY_SLACK_BOT_TOKEN / NIGHTLY_SLACK_CONTROL_CHANNEL 未設定。終了"; exit 1; }
+command -v jq >/dev/null || { echo "[ctl] jq が必要"; exit 1; }
+
+# --- Slack Web API (curl) ---------------------------------------------------
+api() { # api <method> <field=val> ...
+  local method="$1"; shift
+  local args=(); local kv
+  for kv in "$@"; do args+=(--data-urlencode "$kv"); done
+  curl -sS -X POST "https://slack.com/api/$method" \
+    -H "Authorization: Bearer $BOT" \
+    -H "Content-type: application/x-www-form-urlencoded" "${args[@]}"
+}
+post() { api chat.postMessage "channel=$CH" "text=$1" >/dev/null; }
+
+# --- テーマ照会 -------------------------------------------------------------
+themes_available() { find "$THEMES_DIR" -maxdepth 1 -name '*.md' ! -name '_TEMPLATE.md' -printf '%f\n' 2>/dev/null | sed 's/\.md$//' | sort; }
+themes_active()    { grep -vE '^[[:space:]]*(#|$)' "$ROTATION" 2>/dev/null; }
+theme_known() {  # themes/<t>.md があるか、backend-smoke-* (共有テーマ) か
+  local t="$1"
+  [[ -f "$THEMES_DIR/$t.md" ]] && return 0
+  [[ "$t" == backend-smoke-* && -f "$THEMES_DIR/backend-smoke.md" ]] && return 0
+  return 1
+}
+is_active() { themes_active | grep -qxF "$1"; }   # pipe形 (grep -q + <() は競合で空読みしうる)
+
+allowed() {  # 実行系を許可された user か (ALLOW 未設定なら不許可)
+  local u="$1" x
+  [[ -z "$ALLOW" ]] && return 1
+  for x in ${ALLOW//,/ }; do [[ "$x" == "$u" ]] && return 0; done
+  return 1
+}
+
+# --- コマンド ---------------------------------------------------------------
+cmd_help() {
+  post ":robot_face: *audit 制御*  使い方:
+\`!audit list\`    有効/利用可能なテーマ一覧
+\`!audit status\`  今日のテーマ・直近ログ
+\`!audit enable <name>\`  テーマを有効化 (rotation 追記)
+\`!audit disable <name>\` テーマを無効化 (rotation 削除)
+\`!audit run <name>\`     今すぐ実行 (完了は通知で)"
+}
+cmd_list() {
+  local act av
+  act="$(themes_active | paste -sd' ' -)"
+  av="$(themes_available | paste -sd' ' -)"
+  post ":card_index_dividers: *監査テーマ*
+• 有効(rotation): ${act:-なし}
+• 利用可能(themes/): ${av:-なし}
+\`!audit enable/disable/run <name>\` で操作"
+}
+cmd_status() {
+  mapfile -t T < <(themes_active)
+  local sel="(有効テーマなし)"
+  if ((${#T[@]})); then
+    local doy; doy=$(date +%j)        # 10# で 008/009 の8進エラーを回避
+    sel="${T[$((10#$doy % ${#T[@]}))]}"
+  fi
+  local last tailtxt=""
+  last="$(ls -t "$LOG_DIR"/*.run.log 2>/dev/null | head -1)"
+  [[ -n "$last" ]] && tailtxt="$(tail -n 3 "$last" 2>/dev/null)"
+  post ":calendar: 今日のテーマ: *$sel*  (有効 ${#T[@]} 件)
+直近ログ: ${last:-なし}
+\`\`\`
+${tailtxt}
+\`\`\`"
+}
+cmd_enable() {
+  local t="$1"
+  theme_known "$t" || { post ":x: \`themes/$t.md\` が無い (利用可能は \`!audit list\`)"; return; }
+  is_active "$t" && { post ":information_source: \`$t\` は既に有効"; return; }
+  printf '%s\n' "$t" >> "$ROTATION"
+  post ":white_check_mark: \`$t\` を有効化 (rotation に追記)"
+}
+cmd_disable() {
+  local t="$1"
+  is_active "$t" || { post ":information_source: \`$t\` は有効リストに無い"; return; }
+  local tmp; tmp="$(mktemp)"
+  awk -v t="$t" '{ s=$0; gsub(/^[ \t]+|[ \t]+$/,"",s); if(s==t) next; print }' "$ROTATION" > "$tmp" && mv "$tmp" "$ROTATION"
+  post ":white_check_mark: \`$t\` を無効化 (rotation から削除)"
+}
+cmd_run() {
+  local t="$1"
+  theme_known "$t" || { post ":x: \`themes/$t.md\` が無い"; return; }
+  post ":rocket: \`$t\` を実行開始 (完了は通知で報告します)"
+  nohup "$RUNNER" "$t" >>"$LOG_DIR/cron.log" 2>&1 &
+}
+
+dispatch() {
+  local user="$1" text="$2" tag cmd arg
+  read -r tag cmd arg _ <<<"$text"
+  [[ "$tag" != "!audit" ]] && return
+  case "$cmd" in
+    list)    cmd_list ;;
+    status)  cmd_status ;;
+    help|"") cmd_help ;;
+    enable|disable|run)
+      if ! allowed "$user"; then
+        post ":lock: \`$cmd\` は許可ユーザーのみ (NIGHTLY_SLACK_ALLOW_USERS)"; return
+      fi
+      [[ -z "$arg" ]] && { post ":x: 使い方: \`!audit $cmd <theme>\`"; return; }
+      case "$cmd" in
+        enable)  cmd_enable  "$arg" ;;
+        disable) cmd_disable "$arg" ;;
+        run)     cmd_run     "$arg" ;;
+      esac
+      ;;
+    *) post ":grey_question: 不明なコマンド \`$cmd\`  (\`!audit help\`)" ;;
+  esac
+}
+
+# --- メインループ -----------------------------------------------------------
+# 初回は履歴をリプレイしないよう「今」を基準にする (oldest は exclusive)。
+if [[ -f "$STATE" ]]; then LAST="$(cat "$STATE")"; else LAST="$(date +%s).000000"; printf '%s\n' "$LAST" > "$STATE"; fi
+echo "[ctl] start channel=$CH poll=${POLL}s allow=${ALLOW:-<none>}"
+while true; do
+  resp="$(api conversations.history "channel=$CH" "oldest=$LAST" "limit=50")"
+  if [[ "$(jq -r '.ok // false' <<<"$resp" 2>/dev/null)" == "true" ]]; then
+    while IFS=$'\t' read -r ts user text; do
+      [[ -z "$ts" ]] && continue
+      dispatch "$user" "$text"
+      LAST="$ts"; printf '%s\n' "$LAST" > "$STATE"
+    done < <(jq -r '.messages | sort_by(.ts) | .[]
+                    | select(.subtype==null and (has("bot_id")|not))
+                    | [.ts, (.user//""), (.text//"")] | @tsv' <<<"$resp")
+  else
+    echo "[ctl] api err: $(jq -r '.error // "?"' <<<"$resp" 2>/dev/null)"
+  fi
+  sleep "$POLL"
+done


### PR DESCRIPTION
## 概要
webhook(送信専用)に加え、**Slack → ホストの受信経路**を追加。制御チャンネルに
`!audit <cmd>` と書くと監査テーマの一覧/有効化/無効化/即時実行ができる。

## 仕組み
- `slack_control.sh`: NAT 内・pip 無しでも動くよう **curl + jq** だけで制御チャンネルを
  ~15 秒間隔で poll し、コマンドを実行・返信 (公開エンドポイント/WebSocket/外部パッケージ不要)。
  - `!audit list` / `status` … 閲覧 (誰でも)
  - `!audit enable|disable <theme>` … rotation.txt を編集 (許可ユーザーのみ)
  - `!audit run <theme>` … run_nightly_audit.sh をバックグラウンド起動 (許可ユーザーのみ)
- `slack_control.service`: systemd user 常駐ユニット (env を source して起動)。
- `install_cron.sh` env 雛形 / `README.md` に設定手順を追記。

## 安全性
- `enable/disable/run` は `NIGHTLY_SLACK_ALLOW_USERS` のユーザーのみ (未設定だと実行系は無効)。
- `run` が起動する監査も `audit_settings.json` の deny 下で走るため、EXP/force-push/
  main push/`rm -rf`/`common` 編集等はボット経由でも不可。多重起動は runner の flock が防ぐ。
- webhook は claude に渡さない設計のまま (投稿はハーネス)。

## 検証
構文チェック + enable/disable/重複判定/allowlist/コマンド解析の単体テスト全通過
(`grep -q` + プロセス置換の競合バグを発見してパイプ形に修正)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)