### PR TITLE
docs+feat: main() は acsl.utils.realtime.spin を標準に + update_common が host clone も pull

### DIFF
--- a/commands/scripts/update_common
+++ b/commands/scripts/update_common
@@ -10,6 +10,16 @@ source $ACSL_ROS2_DIR/docker/common/scripts/super_echo
 
 IMAGE=${1:-image_${PROJECT}${x86}}
 
+# ホスト側 clone ($ACSL_WORK_DIR/common) を最新化してからイメージへ焼く。
+# (project の setup が読み取り専用にしているため一時的に書込み許可して pull)
+if [[ -n "${ACSL_WORK_DIR:-}" && -d "$ACSL_WORK_DIR/common/.git" ]]; then
+  gecho "UPDATE_COMMON: git pull $ACSL_WORK_DIR/common"
+  chmod -R u+w "$ACSL_WORK_DIR/common"
+  git -C "$ACSL_WORK_DIR/common" pull --ff-only \
+    || recho "git pull failed — 現在のローカル copy のまま続行"
+  chmod -R a+rx,a-w "$ACSL_WORK_DIR/common"
+fi
+
 gecho "UPDATE_COMMON: install latest project_common into ${IMAGE}"
 
 dup --image=${IMAGE} dev

--- a/for_new_project.md
+++ b/for_new_project.md
@@ -70,6 +70,30 @@ source /root/ros2_ws/install/setup.bash
 ros2 run <package_name> <executable_name>
 ```
 
-## 9. 補足
+## 9. メインノードの main() 定型 (必須)
+
+制御ループを持つノードの `main()` は project_common の
+`acsl.utils.realtime.spin` を使うこと:
+
+```python
+from acsl.utils.realtime import spin
+
+def main(args=None):
+    rclpy.init(args=args)
+    node = MyNode()
+    spin(node)      # executor 選択 + GC 対策 + spin + destroy の定型
+    rclpy.shutdown()
+```
+
+理由: rclpy (jazzy) の `MultiThreadedExecutor` は購読トラフィックがあると
+busy-loop してタイマーが飢餓する (40Hz timer 実測: MTE+購読 p50=72ms/
+max=489ms/CPU104% vs Single p50=25.0ms/CPU4%)。引数なしではさらに CPU
+コア数分のスレッドを生成する。project_drone2 の実機で「制御ステップが
+散発的に数百 ms 停止」の原因になった (project_drone2#127)。
+`spin()` は SingleThreadedExecutor 既定 + GC 世代2の停止抑制まで行う。
+ブロックする処理 (HTTP/serial 等) はコールバックに置かず独自スレッドへ。
+一時的に戻す場合は env `ACSL_EXECUTOR=multi[:N]`。
+
+## 10. 補足
 - `commands/scripts/`に便利コマンド（`dps`, `dlogs`, `dup`など）がある。
 - ROSパッケージは`packages/`配下に配置する。


### PR DESCRIPTION
## 概要

project_drone2 で特定した rclpy MultiThreadedExecutor の busy-loop 問題 (acsl-tcu/project_drone2#127, acsl-tcu/project_common#1) のエコシステム標準化:

1. **for_new_project.md**: メインノードの `main()` は `acsl.utils.realtime.spin(node)` を使う定型を必須として追記 (executor 選択 + GC 対策込み。理由・ベンチ数値・ブロッキング処理の指針も記載)
2. **update_common**: イメージへ pip install する前に**ホスト側 clone (`$ACSL_WORK_DIR/common`) を `git pull`** するように改良。既存デプロイ機への common 更新が `update_common` 一発で完結する (setup が付けている読み取り専用パーミッションは pull の間だけ解除→復元)

## 関連 PR

- acsl-tcu/project_common#1 — `acsl.utils.realtime` 本体
- acsl-tcu/project_drone2#127 — drone2 適用済み (実機で CPU 91%→数%、数百ms停止が消滅)
- acsl-tcu/project_rf_rover#72 — rover 適用

🤖 Generated with [Claude Code](https://claude.com/claude-code)