### PR TITLE
fix(dup): .env が無いとき空ファイルを用意しコンテナ起動を安定化

### DIFF
--- a/commands/scripts/dup
+++ b/commands/scripts/dup
@@ -84,6 +84,15 @@ done
 source $ACSL_ROS2_DIR/docker/common/scripts/super_echo
 source $ACSL_ROS2_DIR/bashrc
 
+# .env が無いと Docker が bind-mount 元 ($ACSL_WORK_DIR/.env) を空ディレクトリとして
+# 自動生成し、コンテナ内 /root/ros2_ws/.env もディレクトリ化する
+# (docker-compose.yml: $ACSL_WORK_DIR/.env:/root/ros2_ws/.env)。それが dcommit で
+# イメージに焼き込まれると、後からホストに .env ファイルを置いたとき file/dir 不整合で
+# "not a directory" マウント失敗になる。無いときだけ空ファイルを用意して回避する。
+if [ -n "$ACSL_WORK_DIR" ] && [ ! -e "$ACSL_WORK_DIR/.env" ]; then
+  touch "$ACSL_WORK_DIR/.env"
+fi
+
 # 呼び出し元シェルが持っていた RID と設定ファイル($ACSL_ROS2_DIR/bashrc)の RID が
 # 食い違っている場合に通知する。別端末で setrid した後など、手元シェルが古い RID の
 # まま取り残されているケースを検知する (dup 自体は常にファイル値で起動する)。


### PR DESCRIPTION
## 背景
`.env` が存在しない状態で `dup` / `build_project` を起動すると、Docker が bind-mount 元 (`$ACSL_WORK_DIR/.env`) を**空ディレクトリ**として自動生成する。コンテナ内 `/root/ros2_ws/.env` もディレクトリ化し、それが `build_project` 末尾の `dcommit` でイメージに焼き込まれる。後からホストに実 `.env`（ファイル）を置くと file/dir 不整合となり、次回起動で:

```
error mounting ".../.env" to rootfs at "/root/ros2_ws/.env": ... not a directory
```

で失敗する。

## 変更
`dup` のコンテナ起動前（`source bashrc` 直後）に、**無いときだけ**空ファイルを用意するガードを追加:

```bash
if [ -n "$ACSL_WORK_DIR" ] && [ ! -e "$ACSL_WORK_DIR/.env" ]; then
  touch "$ACSL_WORK_DIR/.env"
fi
```

- 既存 `.env` には触れない（mtime 変更なし・既存 dir にも触れない）
- 空ファイルで OK（launch スクリプトの source / python-dotenv は無害）
- 直接 `dup <name>` / `dup all`→`project_launch.sh`→各 `dup` / `build_project`→`dup --image= build` の全経路がこの1本を通るため一括カバー
- `bash -n` 構文チェック済み

## 注意
既に `.env/` ディレクトリが焼き込まれたイメージは本 PR では直らない。該当イメージは残骸削除＋再コミット、または `dbuild` 再生成でクリーンにする必要がある。

🤖 Generated with [Claude Code](https://claude.com/claude-code)