### PR TITLE
fix(my_packages): <name> 抽出を package.xml に限定し不正トークン混入を防ぐ

### DIFF
--- a/docker/common/scripts/my_packages
+++ b/docker/common/scripts/my_packages
@@ -3,7 +3,10 @@
 if [ ${HOSTNAME:0:1} == "D" ]; then
   ros_packages=$(ls ~/ros2_ws/src/ros_packages)
 else
-  ros_packages=$(grep -RhoP '(?<=<name>)[^<]+' $ACSL_WORK_DIR/packages  | sort -u)
+  # --include=package.xml で対象を package.xml に限定する。
+  # 限定しないと packages/ 配下のコメント/README/docstring に含まれる <name> 文字列まで
+  # 拾い、colcon --packages-select に不正トークンが混入する (unknown package 警告)。
+  ros_packages=$(grep -RhoP '(?<=<name>)[^<]+' --include=package.xml $ACSL_WORK_DIR/packages  | sort -u)
 fi
 
 echo ${ros_packages/README_ROS.md/}


### PR DESCRIPTION
## 背景
`build_project` を引数なしで実行すると `my_packages` がビルド対象を自動列挙するが、その実装

```bash
grep -RhoP '(?<=<name>)[^<]+' $ACSL_WORK_DIR/packages | sort -u
```

が `packages/` 配下の**全ファイル**から `<name>...` を抽出するため、`package.xml` 以外のコメント / README / docstring に含まれる `<name>` 文字列まで拾ってしまう。結果、`colcon build --packages-select` に不正トークンが混入し以下の警告が出ていた:

```
WARNING:colcon...:ignoring unknown package '.yaml' in --packages-select
WARNING:colcon...:ignoring unknown package '→' in --packages-select
WARNING:colcon...:ignoring unknown package 'IOField' in --packages-select
WARNING:colcon...:ignoring unknown package ':=' in --packages-select   ...
```

（実パッケージはビルドされるため実害はないが、ノイズかつ将来的に危険）

混入源の例:
- `rf_rover/tools/reference/building_reference.py` … `<name>.yaml → /common/occupancy/`
- `rf_rover/rover_main.py` … `<name>/config を引く。`
- `rf_rover/rf_rover/readme_contract.md` … `<name>: IOField`
- `megarover3_bringup/launch/robot.launch.py` … `:=`

## 変更
`grep` に `--include=package.xml` を付け、抽出対象を `package.xml` に限定:

```bash
grep -RhoP '(?<=<name>)[^<]+' --include=package.xml $ACSL_WORK_DIR/packages | sort -u
```

## 検証
実体 `/usr/bin/grep` で before/after を比較:

- before: junk 5 種 + 実パッケージ10個
- after: 実パッケージ10個のみ（`bcps_bridge bcps_bridge_msgs megarover3 megarover3_bringup megarover_description rf_interfaces rf_rover sitl vl53l1x vs_rover_options_description`）

実パッケージ（`megarover_description` 含む）は従来どおり全て抽出され、junk のみ除去されることを確認済み。`bash -n` 構文チェック済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)