### PR TITLE
fix: nightly audit の無人実行を修復 (認証・acsl env 継承・busy ゲート)

### DIFF
--- a/nightly_audit/audit_settings.json
+++ b/nightly_audit/audit_settings.json
@@ -32,7 +32,6 @@
       "Bash(rm -rf *)",
       "Bash(sudo *)",
       "Edit(**/common/**)",
-      "Write(**/common/**)",
       "Edit(**/.git/**)",
       "Read(**/.env)",
       "Read(~/ENV/**)",

--- a/nightly_audit/run_nightly_audit.sh
+++ b/nightly_audit/run_nightly_audit.sh
@@ -211,6 +211,19 @@ fi
 echo "[nightly-audit] sync targets to latest main ..." | tee -a "$LOG"
 sync_targets "$LOG" || true   # sync の不調で監査全体を止めない (origin/main は fetch 済)
 
+# --- backend-smoke: acsl env を claude セッションに継承させる ----------------
+# dup 等の acsl コマンドは deploy checkout の .acsl/bashrc が PATH/env を作る設計だが、
+# cron 起動の headless セッションにはそれが無く dup が rc=127 になる
+# (2026-07-13〜15 監査ブロッカー A)。dup は先頭で $ACSL_ROS2_DIR/bashrc を source して
+# PROJECT/ROS_DOMAIN_ID 等を自力復元するので、ここでは PATH と WORK/ROS2 DIR だけ渡す。
+# 副作用: 下の cd "${ACSL_WORK_DIR:-$HOME}" により claude は deploy checkout で起動する。
+if [[ -n "$SMOKE_PATH" && -d "$SMOKE_PATH/.acsl" ]]; then
+  export ACSL_WORK_DIR="$SMOKE_PATH"
+  export ACSL_ROS2_DIR="$SMOKE_PATH/.acsl"
+  export PATH="$SMOKE_PATH/.acsl/commands/scripts:$SMOKE_PATH/.acsl/docker/common/scripts:$PATH"
+  echo "[nightly-audit] acsl env exported (ACSL_WORK_DIR=$SMOKE_PATH)" | tee -a "$LOG"
+fi
+
 # --- claude 無人起動 --------------------------------------------------------
 # --bare 禁止  : --bare は CLAUDE_CODE_OAUTH_TOKEN を読まず "Not logged in" になる
 #                (2.1.207 で確認)。headless は -p だけで keyring ハング等は起きない。

--- a/nightly_audit/run_nightly_audit.sh
+++ b/nightly_audit/run_nightly_audit.sh
@@ -192,6 +192,42 @@ if [[ "${DRY_RUN:-0}" == "1" ]]; then
   echo "----- DRY_RUN: prompt -----"; echo "$PROMPT"; exit 0
 fi
 
+# --- backend-smoke: ホスト使用中ゲート (監査 2026-07-13〜15 ブロッカー B) -----
+# 対象 project 以外のコンテナが Up のまま bringup すると GPU/DDS/ポートで干渉しうる。
+# その場合は claude を起動せず、スキップした旨をレポート/Slack に残して正常終了する。
+# 対象 project のコンテナ名 = $SMOKE_PATH/launcher/launch_<name>.sh の <name>
+# (dup が CONTAINER_NAME に使う。インスタンス <name>_<inst> も同一視)。
+# 常駐コンテナ (例: switchbot) は env の NIGHTLY_SMOKE_IGNORE=name1,name2 で除外する。
+if [[ -n "$SMOKE_PATH" ]] && command -v docker >/dev/null 2>&1; then
+  mapfile -t OWN < <(ls "$SMOKE_PATH/launcher/" 2>/dev/null | sed -nE 's/^launch_(.+)\.sh$/\1/p')
+  FOREIGN=()
+  while IFS= read -r c; do
+    [[ -z "$c" ]] && continue
+    keep=1
+    for o in "${OWN[@]}"; do [[ "$c" == "$o" || "$c" == "${o}_"* ]] && { keep=0; break; }; done
+    [[ ",${NIGHTLY_SMOKE_IGNORE:-}," == *",$c,"* ]] && keep=0
+    [[ "$keep" == 1 ]] && FOREIGN+=("$c")
+  done < <(docker ps --format '{{.Names}}' 2>/dev/null)
+  if [[ ${#FOREIGN[@]} -gt 0 ]]; then
+    REPORT="$LOG_DIR/${DATE}-${THEME}.md"
+    {
+      echo "# Nightly Audit ${DATE} — ${THEME} (host: $(hostname))"
+      echo
+      echo "## 結論"
+      echo "**smoke スキップ (ホスト使用中ゲート・要注意)。claude 未起動・PR なし・既存コンテナには未接触。**"
+      echo
+      echo "対象 project (${SMOKE_DEPLOY}) 以外のコンテナが Up のため、干渉回避で bringup せず終了:"
+      for c in "${FOREIGN[@]}"; do echo "- \`${c}\`"; done
+      echo
+      echo "常駐等で無視してよいコンテナは env の \`NIGHTLY_SMOKE_IGNORE\` (カンマ区切り) に追加する。"
+    } > "$REPORT"
+    echo "[nightly-audit] busy gate: 対象外コンテナ Up (${FOREIGN[*]}) → smoke スキップ" | tee -a "$LOG"
+    rc=0
+    notify_slack || true
+    exit 0
+  fi
+fi
+
 # --- 無人実行の前提チェック (README「無人運用の前提」参照) -------------------
 # cron は対話ログインの資格 (keyring / ~/.claude/.credentials.json) を TTY 無しで
 # 使えない。必ず env でトークンを渡す。どちらか一方が要る:

--- a/nightly_audit/run_nightly_audit.sh
+++ b/nightly_audit/run_nightly_audit.sh
@@ -212,7 +212,8 @@ echo "[nightly-audit] sync targets to latest main ..." | tee -a "$LOG"
 sync_targets "$LOG" || true   # sync の不調で監査全体を止めない (origin/main は fetch 済)
 
 # --- claude 無人起動 --------------------------------------------------------
-# --bare       : OAuth refresh / keyring / plugin ロードをスキップ (無人必須)
+# --bare 禁止  : --bare は CLAUDE_CODE_OAUTH_TOKEN を読まず "Not logged in" になる
+#                (2.1.207 で確認)。headless は -p だけで keyring ハング等は起きない。
 # dontAsk      : 許可リスト外は静かに拒否 = ハングしない。deny>ask>allow で deny 最優先。
 # --settings   : audit_settings.json (allow=監査が使うコマンド, deny=破壊系ハードガード)
 CLAUDE_BIN="${CLAUDE_BIN:-claude}"
@@ -221,7 +222,7 @@ SETTINGS="$HERE/audit_settings.json"
 
 cd "${ACSL_WORK_DIR:-$HOME}"
 set +e
-"$CLAUDE_BIN" --bare -p "$PROMPT" \
+"$CLAUDE_BIN" -p "$PROMPT" \
   --permission-mode "$PERMISSION_MODE" \
   --settings "$SETTINGS" >>"$LOG" 2>&1
 rc=$?


### PR DESCRIPTION
## 背景

夜間監査は 2026-07-07 の初回定期実行から一度も成功していなかった。原因は多段:

1. cron の最小 PATH に `~/.local/bin` が無く `claude` が rc=127
   (→ ホスト側 `~/.config/acsl-nightly-audit.env` に PATH 追記で対処済み・リポ外)
2. `--bare` が `CLAUDE_CODE_OAUTH_TOKEN` を読まず "Not logged in" (2.1.207 で確認)
3. headless セッションに acsl env が無く `dup` が rc=127
   (07-13〜15 監査レポートのブロッカー A、3晩連続)
4. ホスト使用中に backend-smoke を走らせると干渉リスク (同ブロッカー B)

## 変更

- `--bare` を除去 (token 認証を通すため。headless は `-p` のみで問題なし)
- backend-smoke 時に `ACSL_WORK_DIR` / `ACSL_ROS2_DIR` / PATH を claude セッションへ export
  (`dup` は先頭で `.acsl/bashrc` を source するので残りの env は自力復元される)
- ホスト使用中ゲート: 対象 project (`$SMOKE_PATH/launcher/launch_<name>.sh` 由来) 以外の
  コンテナが Up なら claude を起動せずスキップ報告 (md + Slack)。常駐コンテナは
  env の `NIGHTLY_SMOKE_IGNORE=name1,name2` で除外
- `audit_settings.json` の無効な `Write(**/common/**)` deny 行を削除
  (`Edit(**/common/**)` が Write 含む全編集ツールをカバー)

## 検証

- 07-13: cron 相当環境で手動フル実行 → 監査完走 rc=0・レポート生成・Slack 投稿成功
- 07-16: cron 相当環境 + dontAsk + audit_settings で headless claude から `dup -h` が
  exit 0 (Usage 表示) になることをリハーサル確認
- 07-16: busy ゲートを実ホスト (isaac-sim / slam_toolbox Up, switchbot は ignore) で
  テスト実行 → スキップ報告 md 生成・claude 未起動・rc=0 を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)