### PR TITLE
feat: nightly に image-refresh テーマ (Hub ベース jazzy_x86 の定期再ビルド & push)

### DIFF
--- a/nightly_audit/audit_settings.json
+++ b/nightly_audit/audit_settings.json
@@ -15,7 +15,11 @@
       "Bash(colcon *)", "Bash(python -m py_compile *)", "Bash(python3 -m py_compile *)",
       "Bash(bash -n *)", "Bash(dup *)", "Bash(dps*)", "Bash(dlogs *)", "Bash(din *)",
       "Bash(build_project*)", "Bash(drm *)", "Bash(acsl *)",
-      "Bash(docker ps*)", "Bash(docker logs *)", "Bash(docker rm *)"
+      "Bash(docker ps*)", "Bash(docker logs *)", "Bash(docker rm *)",
+      "Bash(docker images*)", "Bash(docker inspect *)", "Bash(df *)",
+      "Bash(docker pull ros:*)", "Bash(dbuild *)", "Bash(dpush jazzy_x86)",
+      "Bash(docker run --rm kasekiguchi/acsl-common:jazzy_x86 *)",
+      "Bash(docker image prune -f)"
     ],
     "deny": [
       "Bash(dup * EXP*)",

--- a/nightly_audit/rotation.txt
+++ b/nightly_audit/rotation.txt
@@ -22,6 +22,10 @@ backend-smoke-drone-SITL_OMNI
 backend-smoke-rover-SIM
 backend-smoke-rover-isaacsim
 
+# Hub ベースイメージ (jazzy_x86) の定期再ビルド & push。放置すると派生イメージと
+# apt スキューが起きる (2026-07 実例)。11日周期で十分新鮮に保てる。
+image-refresh
+
 # --- 予約 (themes/ を作ったら上に移して有効化) ---
 # config-consistency   rover.yaml 唯一デフォルト源・ハードコード禁止規約の遵守
 # deps-drift           base image / ROS2 distro / Python pin のバージョンずれ

--- a/nightly_audit/run_nightly_audit.sh
+++ b/nightly_audit/run_nightly_audit.sh
@@ -260,6 +260,18 @@ if [[ -n "$SMOKE_PATH" && -d "$SMOKE_PATH/.acsl" ]]; then
   echo "[nightly-audit] acsl env exported (ACSL_WORK_DIR=$SMOKE_PATH)" | tee -a "$LOG"
 fi
 
+# --- image-refresh: acsl infra コマンド (dbuild/dpush) を claude に継承 -------
+# dbuild は $ACSL_ROS2_DIR (docker/ と dockerfiles/ の解決) と ROS_DISTRO (build-arg) が
+# 必要。dontAsk では env 前置コマンド (ROS_DISTRO=... dbuild) が deny されるため、
+# ここで export して Bash tool に継承させる。checkout は監査が動くこのリポ自身を使う。
+if [[ "$THEME" == "image-refresh" ]]; then
+  INFRA_DIR="$(cd "$HERE/.." && pwd)"
+  export ACSL_ROS2_DIR="$INFRA_DIR"
+  export ROS_DISTRO="jazzy"
+  export PATH="$INFRA_DIR/commands/scripts:$INFRA_DIR/docker/common/scripts:$PATH"
+  echo "[nightly-audit] acsl infra env exported (ACSL_ROS2_DIR=$INFRA_DIR, ROS_DISTRO=jazzy)" | tee -a "$LOG"
+fi
+
 # --- claude 無人起動 --------------------------------------------------------
 # --bare 禁止  : --bare は CLAUDE_CODE_OAUTH_TOKEN を読まず "Not logged in" になる
 #                (2.1.207 で確認)。headless は -p だけで keyring ハング等は起きない。

--- a/nightly_audit/themes/image-refresh.md
+++ b/nightly_audit/themes/image-refresh.md
@@ -1,0 +1,49 @@
+# テーマ: image-refresh (Hub ベースイメージの定期再ビルド & push)
+
+> Hub (`kasekiguchi/acsl-common`) のベースタグが古いまま放置されると、派生イメージ
+> (image_*, mavros2 等) との間で apt パッケージのスキューが全ホストに波及する。
+> 由来: 2026-07 に `jazzy`/`jazzy_x86` が約2ヶ月前のままでスキューが発生した。
+> このテーマは rotation で回ってくるたびに **このホストでビルドできるベースタグを
+> 上流から作り直して push** する。PR は作らない。成果物は更新された Hub タグとレポート。
+
+## 対象
+- `kasekiguchi/acsl-common:jazzy_x86` のみ (このホスト = x86)。
+- arm 版 `jazzy` (無印) は arm ホスト or qemu が必要でこのホストでは**ビルド不可**。
+  毎回レポートの「要相談」に「arm 側は別ホストでの運用が未整備」と1行残す
+  (arm ホストに同運用が入ったらこの記載を落とす)。
+- `humble` 系は現行 project (drone2 / rf_rover = jazzy) が使っていないため対象外。
+
+## 手順 (この順で。ハーネスが ACSL_ROS2_DIR / ROS_DISTRO=jazzy / PATH を export 済み)
+1. **事前チェック** (どれか失敗なら以降を中止して要相談):
+   - `df -h /` — 空き 40GB 未満なら中止 (ビルド中間層で一時的に膨らむ)。
+   - `docker images kasekiguchi/acsl-common:jazzy_x86` — 現行の IMAGE ID と CREATED を記録。
+2. **上流を更新**: `docker pull ros:jazzy` — digest が変わったか出力から記録
+   (Image is up to date でもビルドは続行する。apt レベルの更新はベース digest に現れない)。
+3. **再ビルド**:
+   `dbuild ros:jazzy jazzy $ACSL_ROS2_DIR/dockerfiles/dockerfile.base_ros_x86 --no-cache`
+   - `--no-cache` は必須 (キャッシュが残ると apt update/upgrade 層が古いまま再利用される)。
+   - 失敗したら push せず、エラー末尾を添えて要相談。旧タグはそのまま残るので実害なし。
+4. **検証** (push 前に必ず):
+   - `docker images kasekiguchi/acsl-common:jazzy_x86` — IMAGE ID が変わり CREATED が今日。
+   - `docker run --rm kasekiguchi/acsl-common:jazzy_x86 bash -c "source /opt/ros/jazzy/setup.bash && ros2 pkg list | wc -l"`
+     — 300 以上であること (desktop 一式が入っている目安)。
+5. **push**: `dpush jazzy_x86` (認証はホストの保存済み credential。失敗したら要相談)。
+6. **後始末**: `docker image prune -f` (旧タグが dangling 化して 7GB 級で溜まるため必須。
+   dangling のみ削除するので稼働中コンテナ・タグ付きイメージには影響しない)。
+
+## レポートに必ず書くこと
+- 旧/新 IMAGE ID と CREATED、`ros:jazzy` の digest 更新有無、検証結果 (pkg 数)、
+  push 成否、prune で回収した容量。
+- 派生イメージ (image_* 等) は**このテーマでは再ビルドしない** (デプロイ時 / setup で
+  ベースから作り直される設計)。ベース更新が入った晩は「派生は次回 deploy 時に追従」と記載。
+
+## やらないこと (安全境界・絶対)
+- `jazzy_x86` 以外のタグを push しない (image_*, isaac 系, humble, arm 無印を含む)。
+- 稼働中コンテナに触らない (docker stop/rm/restart をしない)。
+- `docker image prune` は `-f` (dangling のみ) 以外の形で使わない
+  (`-a` は全未使用イメージを消すので絶対に使わない)。
+- ビルド失敗時に Dockerfile や compose を修正して再試行しない (要相談へ)。
+
+## 検証方法
+- 手順 4 がそのまま検証。加えて push 後に `docker images` の DIGEST 欄 (あれば) か
+  `dpush` 出力の digest をレポートへ転記する。


### PR DESCRIPTION
## 背景

Hub の `kasekiguchi/acsl-common:jazzy`/`jazzy_x86` ベースが約2ヶ月前のまま放置され、派生イメージとの apt スキューが発生した (2026-07)。中期対策として、ベースの再ビルド & push を nightly rotation に組み込む。

## 変更

- `themes/image-refresh.md` 新規: `docker pull ros:jazzy` → `dbuild --no-cache` → 検証 (IMAGE ID/CREATED 更新 + コンテナ内 `ros2 pkg list` 件数) → `dpush jazzy_x86` → `docker image prune -f`。失敗時は push せず要相談。派生イメージは対象外 (deploy 時にベースから追従する設計のまま)
- `rotation.txt` に `image-refresh` 追加 (11日周期)
- `run_nightly_audit.sh`: image-refresh 時に `ACSL_ROS2_DIR` / `ROS_DISTRO=jazzy` / PATH を export (dontAsk では env 前置コマンドが deny されるためハーネス側で用意)
- `audit_settings.json`: `dbuild` / `dpush jazzy_x86` (このタグのみ) / `docker pull ros:*` / 検証用 `docker run --rm kasekiguchi/acsl-common:jazzy_x86 *` / `docker image prune -f` (dangling のみ) を allow に追加

## スコープ外 (テーマ内で毎回要相談として報告)

- arm 版 `jazzy` (無印): このホスト (x86, qemu なし) ではビルド不可。arm ホストでの同運用は未整備
- `humble` 系: 現行 project が未使用

## 検証

- JSON / bash -n / `DRY_RUN=1` でテーマ解決とプロンプト構築を確認
- merge 後に手動フル実行で rebuild→push を監督付きで確認する

🤖 Generated with [Claude Code](https://claude.com/claude-code)