### PR TITLE
fix: image-refresh の docker pull allow ルールが不一致だった問題

### DIFF
--- a/nightly_audit/audit_settings.json
+++ b/nightly_audit/audit_settings.json
@@ -17,7 +17,7 @@
       "Bash(build_project*)", "Bash(drm *)", "Bash(acsl *)",
       "Bash(docker ps*)", "Bash(docker logs *)", "Bash(docker rm *)",
       "Bash(docker images*)", "Bash(docker inspect *)", "Bash(df *)",
-      "Bash(docker pull ros:*)", "Bash(dbuild *)", "Bash(dpush jazzy_x86)",
+      "Bash(docker pull *)", "Bash(dbuild *)", "Bash(dpush jazzy_x86)",
       "Bash(docker run --rm kasekiguchi/acsl-common:jazzy_x86 *)",
       "Bash(docker image prune -f)"
     ],


### PR DESCRIPTION
#46 の追い修正。`Bash(docker pull ros:*)` は `:` 直後の `*` が Claude Code の prefix 記法と衝突してマッチせず、image-refresh テーマが手順2 (docker pull) で毎回 deny → 要相談止まりになっていた (07-16 / 07-17 の2晩 + 本日の手動再現で確認)。

scratch settings での実測で以下を確認済み:
- `Bash(docker pull *)` → `docker pull ros:jazzy` が許可される ✓
- `Bash(docker run --rm kasekiguchi/acsl-common:jazzy_x86 *)` (コロンが rule 中にあっても wildcard が空白区切りなら可) → 許可される ✓

よって pull の rule のみ `Bash(docker pull *)` に変更。

🤖 Generated with [Claude Code](https://claude.com/claude-code)