### PR TITLE
docs: docs-drift 監査 (07-17) の確証指摘 A1-A4 を修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ dps
 
 ## Debug用コマンド
 
-docker/common/scripts 内の便利コマンド
+commands/scripts 内の便利コマンド (gpull のみ docker/common/scripts)
 
 ```bash
 # = git pull + commitしていない編集の削除 + 権限関係の整理

--- a/commands/README_SYSTEMD.md
+++ b/commands/README_SYSTEMD.md
@@ -6,8 +6,8 @@ systemd を利用してHOST起動時にDocker コンテナ立ち上げからROS�
 
 ```
 .
-|- ros2_launch_service    ：serviceの設定
-|- ros2_launch_sh         ：serviceから呼び出す実行ファイル
+|- project_launch_service ：serviceの設定
+|- project_launch_sh      ：serviceから呼び出す実行ファイル
 |- setup.sh               ：serviceの登録用シェルスクリプト
 ```
 
@@ -24,16 +24,16 @@ git pullして来たら以下を実行
 新しいros2 パッケージを導入するとき
 
 - launcher/launch_<package>.sh を追加（書き方は他のlaunchファイル参照）
-- ros2_launch_<project_name>_sh を書き足す（書き足し方は既に書いてある中身参照）
+- project_launch_<project_name>_sh を書き足す（書き足し方は既に書いてある中身参照）
 
-ros2_launch_serviceはsystemd の設定を変更する必要がある場合以外触らなくてOK
+project_launch_serviceはsystemd の設定を変更する必要がある場合以外触らなくてOK
 
 ## 詳細
 
 ros2 run までの自動実行の流れ
 
 HOST上
-systemd => ros2_launch.service => ros2_launch.sh => docker compose up => docker-compose.yml:common =>
+systemd => project_launch.service => project_launch.sh => docker compose up => docker-compose.yml:common =>
 
 DOCKER上
 entrypoint:command => launch_<package>.sh => ros2 run

--- a/docker/README_DOCKER.md
+++ b/docker/README_DOCKER.md
@@ -1,10 +1,10 @@
 # README for Docker system
 
-First read [README_SYSTEM.md](../README_SYSTEM.md) and complete the setup section
+First read [README.md](../README.md) and complete the setup section
 
 ## Terminology
 
-Refer to [README_SYSTEM.md](../README_SYSTEM.md) for the common terminologies.
+Refer to [README.md](../README.md) for the common terminologies.
 
 <https://docs.docker.jp/engine/reference/commandline/compose.html>
 
@@ -32,7 +32,7 @@ Refer to [README_SYSTEM.md](../README_SYSTEM.md) for the common terminologies.
 
 * 飛行システムの起動
 
-[systemdの設定](../systemd_files/README_SYSTEMD.md)が済んでいれば電源投入で自動的に起動する。
+[systemdの設定](../commands/README_SYSTEMD.md)が済んでいれば電源投入で自動的に起動する。
 
 * 開発用コンテナの起動
 
@@ -153,7 +153,7 @@ docker compose --env-file env.estimator up common -d
 docker compose --env-file env.mavlink up common -d
 ```
 
-[setup.sh](../systemd_files/setup.sh)では複数機対応するためnamespaceを指定する記述を追加している。
+[setup.sh](../commands/setup.sh)では複数機対応するためnamespaceを指定する記述を追加している。
 
 ### その他のDocker コマンド
 
@@ -256,7 +256,7 @@ docker container prune
 2'. realsense-ros2をbase imageにして拡張するdockerfileと、docker-compose上のserviceを追加
 3. buildし直す
 4. docker hubにアップロード
-5'. ros2_launch_sh のservice名を変更
+5'. project_launch_sh のservice名を変更
 6. HOST上でgit登録
 
 ###
@@ -267,6 +267,6 @@ docker container prune
   3.1 ROSパッケージを起動するコマンドを書いたlaunch_***.shを
       docker/common/ros_launcherに追加
   3.2 対応するenv.*** をdocker/内に追加
-  3.3 systemd_files/ros2_launch_shに3.1のファイルの起動を追加
+  3.3 commands/project_launch_shに3.1のファイルの起動を追加
 4. HOST上でgitに登録
-5. systemd_files/setup.sh を実行し自動起動の設定をする
+5. commands/setup.sh を実行し自動起動の設定をする

--- a/packages/README_ROS.md
+++ b/packages/README_ROS.md
@@ -36,7 +36,7 @@ ROSパッケージの詳細
 
 * 飛行システムの起動
 
-[systemdの設定](../systemd_files/README_SYSTEMD.md)が済んでいれば電源投入で自動的に起動する。
+[systemdの設定](../commands/README_SYSTEMD.md)が済んでいれば電源投入で自動的に起動する。
 
 * 個別のパッケージの起動（HOSTから）
 


### PR DESCRIPTION
2026-07-17 の nightly docs-drift 監査の確証指摘 (acsl_infra 分 A1〜A4) の適用。

- **A1** `commands/README_SYSTEMD.md`: `ros2_launch_*` → `project_launch_*` リネーム取り残し (フォルダ構成・拡張方法・自動実行フロー)
- **A2** `packages/README_ROS.md:39`: 消えた `../systemd_files/README_SYSTEMD.md` → `../commands/README_SYSTEMD.md`
- **A3** `docker/README_DOCKER.md`: 壊れた相対リンク (`../README_SYSTEM.md` → `../README.md`、`systemd_files/` 系 → `commands/` 系)。同類の取り残し2箇所 (リンクラベル・:259 の旧名) も追従
- **A4** `README.md:150`: Debug コマンド設置場所を実態に追従 (`commands/scripts`、`gpull` のみ `docker/common/scripts`)

修正先はすべて監査が Read で実在確認済みの一意マッピング。適用時に再検証した。

レポート: nightly_audit/logs/2026-07-17-docs-drift.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)