### PR TITLE
fix(dds): builtin transport の default に max_msg_size=1400 を付与

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -57,7 +57,10 @@ services:
       - x86=$x86
       - HOST_PATH=$PATH
       - RMW_IMPLEMENTATION=rmw_${RMW:-fastrtps}_cpp
-      - FASTDDS_BUILTIN_TRANSPORTS=${FASTDDS_BUILTIN_TRANSPORTS:-UDPv4}
+      # max_msg_size を MTU 未満に制限し、大 latched メッセージ (/map ≈835KB 等) が
+      # IP フラグメントされて WSL2 で落ちるのを防ぐ (FASTRTPS_DEFAULT_PROFILES_FILE を
+      # 使わず builtin transport のみのコンテナ (例: nav2) 向け)。
+      - "FASTDDS_BUILTIN_TRANSPORTS=${FASTDDS_BUILTIN_TRANSPORTS:-UDPv4?max_msg_size=1400B&sockets_size=4MB}"
       - ROS_USE_SIM_TIME=${ROS_USE_SIM_TIME:-false}
       - ENV_BUILDING=${ENV_BUILDING:-bld10} # active 建屋名 (environment_<name>)
       # WSL : thanks to : https://dev.classmethod.jp/articles/wsl2-docker-gui-app-windows-display/


### PR DESCRIPTION
## 背景
WSL2 上で `dup nav2` 起動後、`/map`(≈835KB)を `ros2 topic echo` できない。`/tf_static` 等の小さい topic は取れる。

## 原因
`dup nav2` 等の compose 起動コンテナは `FASTRTPS_DEFAULT_PROFILES_FILE`(XML)を使わず `FASTDDS_BUILTIN_TRANSPORTS` の default 由来で純 UDP。Fast DDS 既定 `maxMessageSize`(65500)だと大サンプルが IP フラグメントされ WSL2 で落ちて reliable でも届かない。

## 修正
compose の default を `UDPv4?max_msg_size=1400B&sockets_size=4MB` に変更。passthrough 形式(`${FASTDDS_BUILTIN_TRANSPORTS:-...}`)は維持し host 側 override 可。

XML を使う経路(EXP/isaac/yolo)は project_rf_rover 側 `fastdds_udp_no_shm.xml` の `maxMessageSize` 追加で別途対応。

## 検証
835KB pub/sub 実測: `UDPv4`=✗ / `UDPv4?max_msg_size=1400B`=✓(RECEIVED 855550 bytes)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)