### PR TITLE
docs: docs-drift 追従 (source 先は $ACSL_ROS2_DIR/bashrc・setup.sh の必須引数)

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ PROJECT="$PROJECT"
 # "$PROJECT" : drone, bos, bos_robot, whill, leg-wheel, rover, turtlebot
 cd ~/ros2/commands
 bash setup.sh $PROJECT
-source ~/.bashrc
+source $ACSL_ROS2_DIR/bashrc
 (sudo reboot )
 dps # 初回でdocker imageを取得できていない場合は表示されるようになるまで時間がかかる
 dlogs "$CONTAINER"
@@ -243,8 +243,8 @@ export PROJECT=whill
 export ROS_DOMAIN_ID=11
 ```
 2. bash setup.sh "$PROEJCT" <br>
-systemdへproject_launch_"$PROJECT"_shを登録。ROS_DOMAIN_ID, 関連コマンド群のパスを.bashrcに登録
-3. source ~/.bashrc <br>
+systemdへproject_launch_"$PROJECT"_shを登録。ROS_DOMAIN_ID, 関連コマンド群のパスを$ACSL_ROS2_DIR/bashrcに登録
+3. source $ACSL_ROS2_DIR/bashrc <br>
 4. vim dockerfiles/dockerfile."$EXT" (optional)<br>
 必要に応じてイメージを拡張するファイルを追加<br>
 5. dsbuild <br>

--- a/commands/README_SYSTEMD.md
+++ b/commands/README_SYSTEMD.md
@@ -16,7 +16,7 @@ systemd を利用してHOST起動時にDocker コンテナ立ち上げからROS�
 git pullして来たら以下を実行
 
 ```bash
-./setup.sh
+./setup.sh <PROJECT>
 ```
 
 ## 拡張方法

--- a/for_new_project.md
+++ b/for_new_project.md
@@ -27,7 +27,7 @@ docker pull kasekiguchi/acsl-common:${IMAGE}
 PROJECT="<PROJECT>"
 cd ~/ros2/commands
 bash setup.sh "${PROJECT}"
-source ~/.bashrc
+source $ACSL_ROS2_DIR/bashrc
 ```
 
 起動確認（必要に応じて再起動）:


### PR DESCRIPTION
## 発見内容 (docs-drift 夜間監査 2026-07-28)

1. **README.md:124, README.md:246-247, for_new_project.md:30** — `bash setup.sh $PROJECT` の直後に `source ~/.bashrc` を案内しているが、setup が環境変数・PATH を登録する先は `$ACSL_ROS2_DIR/bashrc` であり、`~/.bashrc` にはリポ内のどのホスト側スクリプトも書き込まない。
2. **commands/README_SYSTEMD.md:19** — `./setup.sh` を引数なしで案内しているが、setup.sh は PROJECT 引数必須。

## 証拠 (file:line)

- `commands/scripts/set_bashrc:19,22,27` — 書き込み先は `./bashrc` (= `$ACSL_ROS2_DIR/bashrc`) 固定。`commands/setup_bashrc` の全 `set_bashrc` 呼び出しも同様。ホスト側で `~/.bashrc` に触るコードは無し (`set_unique_var` は呼び出し元ゼロのデッドコード、`docker/common/scripts/setup_common.sh` はコンテナ内専用)。
- リポ自身の正規の案内は `source $ACSL_ROS2_DIR/bashrc` — `README.md:202,225`、`commands/scripts/dup:105`。
- dd94f76 で `bashrc` は tracked base + 非追跡生成物に分離されたため、「どの bashrc を source するか」の正確さが以前より重要。
- `commands/setup.sh:10` — `if [ $# -ge 1 ]`、引数なしは `:26` で `Require PROJECT name` を表示して登録処理をスキップ。`README.md:123` は正しい形 (`bash setup.sh $PROJECT`)。

## 修正の根拠

実装 (setup.sh / set_bashrc) 側は変えず、ドキュメントを実挙動に追従。`source $ACSL_ROS2_DIR/bashrc` は既存の正規案内 (README:202,225) と同形で、仮に外部手段で `~/.bashrc` に hook がある環境でも常に正しく働く安全側の書き換え。

## 検証

- 書き込み先・引数ゲートを Read/grep で直接確認 (上記 file:line)。
- ドキュメントのみの変更でコード無変更 (bash -n 対象なし)。

## 確信度

高 (登録先・引数要件はスクリプト本体で確認済み)。

---
夜間自動監査が生成。merge 前にレビューすること。
