### PR TITLE
feat: 環境共有アセット規約 (~/ENV/<name>/repo) の基盤

### DIFF
--- a/commands/scripts/dup
+++ b/commands/scripts/dup
@@ -97,6 +97,10 @@ if [ -n "$ACSL_WORK_DIR" ] && [ ! -e "$ACSL_WORK_DIR/.env" ]; then
   touch "$ACSL_WORK_DIR/.env"
 fi
 
+# ~/ENV (環境共有アセット) も同様: 無いまま compose を起動すると Docker が
+# root 所有で自動生成し、以後 env_sync の clone が権限エラーになるため先に作る
+[ -d "$HOME/ENV" ] || mkdir -p "$HOME/ENV"
+
 # 呼び出し元シェルが持っていた RID と設定ファイル($ACSL_ROS2_DIR/bashrc)の RID が
 # 食い違っている場合に通知する。別端末で setrid した後など、手元シェルが古い RID の
 # まま取り残されているケースを検知する (dup 自体は常にファイル値で起動する)。

--- a/commands/scripts/env_sync
+++ b/commands/scripts/env_sync
@@ -1,0 +1,45 @@
+#! /usr/bin/bash
+# env_sync [<name>...] : 環境リポジトリを ~/ENV/<name>/repo に共有デプロイ/更新する。
+#
+# 規約: ~/ENV = 「環境に関する共有アセット」(ホスト単位で全プロジェクト共有)
+#   ~/ENV/<name>/repo : environment_<name> の git checkout (本コマンドで配備)
+#   ~/ENV/<name>/omni : git 管理外の巨大資産 (USD 等、従来どおり手動配置)
+#
+# 使い方:
+#   env_sync bld10          # environment_bld10 を clone (既存なら pull)
+#   env_sync                # ~/ENV/*/repo を一括 pull
+#
+# 呼び出し元: 各プロジェクトの ./setup (初回配備)。更新は gpull が一括で行う。
+# オフライン等で pull に失敗した場合は警告して手元の版をそのまま使う。
+
+source $ACSL_ROS2_DIR/docker/common/scripts/super_echo 2>/dev/null
+
+ENV_ROOT="${ACSL_ENV_DIR:-$HOME/ENV}"
+
+sync_one() {
+  local name="$1"
+  local dst="$ENV_ROOT/$name/repo"
+  if [ -d "$dst/.git" ]; then
+    echo "env_sync: update $name ($dst)"
+    git -C "$dst" pull --ff-only \
+      || echo "env_sync: WARNING pull failed ($name) — 手元の版を使用します"
+  else
+    echo "env_sync: clone environment_$name -> $dst"
+    mkdir -p "$ENV_ROOT/$name"
+    git clone "git@github.com:acsl-tcu/environment_${name}.git" "$dst"
+  fi
+}
+
+if [ $# -eq 0 ]; then
+  shopt -s nullglob
+  found=0
+  for g in "$ENV_ROOT"/*/repo/.git; do
+    found=1
+    sync_one "$(basename "$(dirname "$(dirname "$g")")")"
+  done
+  [ $found -eq 0 ] && echo "env_sync: $ENV_ROOT に配備済み環境がありません (env_sync <name> で配備)"
+else
+  for n in "$@"; do
+    sync_one "$n"
+  done
+fi

--- a/commands/scripts/gpush
+++ b/commands/scripts/gpush
@@ -26,7 +26,7 @@ git commit -m "$MSG"
 sed -i "s|\$ACSL_ROS2_DIR|$ACSL_ROS2_DIR|g" $ACSL_WORK_DIR/project_launch*.sh
 git push
 
-# clone済み環境リポジトリ
+# clone済み環境リポジトリ (プロジェクト内包型: 共有型への移行完了まで併存)
 for env_dir in $ACSL_WORK_DIR/environments/*/; do
   if [[ -d "${env_dir}.git" ]]; then
     changes=$(git -C "$env_dir" status --porcelain)
@@ -37,6 +37,21 @@ for env_dir in $ACSL_WORK_DIR/environments/*/; do
       ENV_MSG=$(gen_commit_msg "$env_dir" "$env_name" "$1")
       git -C "$env_dir" commit -m "$ENV_MSG"
       git -C "$env_dir" push
+    fi
+  fi
+done
+
+# ~/ENV/<name>/repo (ホスト共有の環境アセット)
+for env_repo in ${ACSL_ENV_DIR:-$HOME/ENV}/*/repo; do
+  if [[ -d "${env_repo}/.git" ]]; then
+    changes=$(git -C "$env_repo" status --porcelain)
+    if [[ -n "$changes" ]]; then
+      echo "git push shared environment: ${env_repo}"
+      env_name=$(basename "$(dirname "$env_repo")")
+      git -C "$env_repo" add .
+      ENV_MSG=$(gen_commit_msg "$env_repo" "$env_name" "$1")
+      git -C "$env_repo" commit -m "$ENV_MSG"
+      git -C "$env_repo" push
     fi
   fi
 done

--- a/docker/common/scripts/gpull
+++ b/docker/common/scripts/gpull
@@ -60,11 +60,20 @@ else
     mv ~/tttt ./bashrc
   fi
 
-  # clone済み環境リポジトリを更新
+  # clone済み環境リポジトリを更新 (プロジェクト内包型: 共有型への移行完了まで併存)
   for env_dir in $ACSL_WORK_DIR/environments/*/; do
     if [[ -d "${env_dir}.git" ]]; then
       echo "gpull environment: ${env_dir}"
       git -C "$env_dir" pull
+    fi
+  done
+
+  # ~/ENV/<name>/repo (ホスト共有の環境アセット) も更新
+  for env_repo in ${ACSL_ENV_DIR:-$HOME/ENV}/*/repo; do
+    if [[ -d "${env_repo}/.git" ]]; then
+      echo "gpull shared environment: ${env_repo}"
+      git -C "$env_repo" pull --ff-only \
+        || echo "gpull: WARNING pull failed (${env_repo}) — 手元の版を使用します"
     fi
   done
 fi

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -94,6 +94,12 @@ services:
       # 占有格子は active 建屋の occupancy を /common/occupancy にも別名 bind
       # (launch_slam_toolbox.sh / launch_nav2.sh を無改修で建屋切替できるよう ENV_BUILDING で切替)
       - $ACSL_WORK_DIR/environments/${ENV_BUILDING:-bld10}/occupancy:/common/occupancy
+      # ~/ENV = 「環境に関する共有アセット」(ホスト単位で全プロジェクト共有)
+      #   ~/ENV/<name>/repo : environment_<name> の git checkout (env_sync で配備、gpull で更新)
+      #   ~/ENV/<name>/omni : git 管理外の巨大資産 (USD 等、従来どおり)
+      #   コンテナからは /ENV/<name>/... で参照 (isaac_sim の -v $HOME/ENV:/ENV と同一規約)。
+      #   上の $ACSL_WORK_DIR/environments (プロジェクト内包型) は共有型への移行完了まで併存
+      - ${HOME}/ENV:/ENV
       - /dev:/dev # GPIO and USB devices
       - vscode-server:/root/.vscode-server # VScode setting (preserve VScode extension)
       - $ACSL_WORK_DIR/packages:/root/ros2_ws/src/ros_packages


### PR DESCRIPTION
`~/ENV` を「環境に関する共有アセット」として再定義し、environment リポジトリをホスト単位で共有する基盤を追加する。

## 背景

これまで environment_* は各プロジェクトの `environments/<name>` に個別 clone されていたため、同一ホスト上で rover / drone / GUI / OMNI がそれぞれコピーを持ち、`gpull` を個別にかけないと鮮度がバラついていた。「常に最新を使う」運用方針に沿って、ホストで1つの checkout を共有する形に変更する。

## 変更

- `commands/scripts/env_sync` (新規): `environment_<name>` を `~/ENV/<name>/repo` に clone / `pull --ff-only`。引数なしで配備済みを一括更新。オフライン時は警告して手元の版を使う
- `gpull` / `gpush`: `~/ENV/*/repo` も同期・push 対象に追加（従来のプロジェクト内包 `environments/` も移行完了まで併存）
- `docker/docker-compose.yml`: `${HOME}/ENV:/ENV` をマウント（isaac_sim の `-v $HOME/ENV:/ENV` と同一規約に統一）
- `commands/scripts/dup`: `~/ENV` を事前 mkdir（compose に先に作らせると root 所有になり、以後の clone が権限エラーになるため）

## 配置規約

```
~/ENV/<name>/repo   environment_<name> の git checkout (env_sync が配備、gpull が更新)
~/ENV/<owner>/omni  USD 等の巨大・秘匿アセット (従来どおり git 管理外・手動配置)
```

## 注意

- **先にこの PR をマージすること。** project 側の `./setup` は `env_sync` が無い場合は旧方式の clone にフォールバックする
- 版は固定しない（常に最新運用）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VVNirLPTv7L5A9uJB4eFWW